### PR TITLE
feat: coingecko proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",
+        "@fastify/caching": "^8.3.0",
         "@fastify/cors": "^8.2.1",
         "@fastify/env": "^4.2.0",
         "@fastify/http-proxy": "^9.0.0",
@@ -20,7 +21,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
-        "@types/node": "^18.0.0",
+        "@types/node": "^18.19.31",
         "@types/tap": "^15.0.5",
         "concurrently": "^7.0.0",
         "fastify-tsconfig": "^1.0.1",
@@ -627,6 +628,16 @@
       "license": "MIT",
       "dependencies": {
         "pkg-up": "^3.1.0"
+      }
+    },
+    "node_modules/@fastify/caching": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/caching/-/caching-8.3.0.tgz",
+      "integrity": "sha512-wxlQS2C9omy7+Aq33XDaHJWO0wF3DH2QFBD/ZHMJnWbL2buUDsjzCNg0TbSbEMHyFi/NiryYYAXVCoFCD7nFTA==",
+      "dependencies": {
+        "abstract-cache": "^1.0.1",
+        "fastify-plugin": "^4.0.0",
+        "uid-safe": "^2.1.5"
       }
     },
     "node_modules/@fastify/cors": {
@@ -1266,9 +1277,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
+      "version": "18.19.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.31.tgz",
+      "integrity": "sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -1309,6 +1324,16 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/abstract-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-cache/-/abstract-cache-1.0.1.tgz",
+      "integrity": "sha512-EfUeMhRUbG5bVVbrSY/ogLlFXoyfMAPxMlSP7wrEqH53d+59r2foVy9a5KjmprLKFLOfPQCNKEfpBN/nQ76chw==",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "lru_map": "^0.3.3",
+        "merge-options": "^1.0.0"
       }
     },
     "node_modules/abstract-logging": {
@@ -1802,6 +1827,14 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/close-with-grace": {
       "version": "1.1.0",
@@ -2602,6 +2635,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -3438,6 +3479,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "license": "ISC",
@@ -3491,6 +3537,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+      "dependencies": {
+        "is-plain-obj": "^1.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/merge-stream": {
@@ -3967,6 +4024,14 @@
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "license": "MIT"
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/react-is": {
       "version": "18.2.0",
@@ -4563,6 +4628,17 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/undici": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
@@ -4573,6 +4649,12 @@
       "engines": {
         "node": ">=12.18"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@fastify/autoload": "^5.0.0",
+    "@fastify/caching": "^8.3.0",
     "@fastify/cors": "^8.2.1",
     "@fastify/env": "^4.2.0",
     "@fastify/http-proxy": "^9.0.0",
@@ -29,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.19.31",
     "@types/tap": "^15.0.5",
     "concurrently": "^7.0.0",
     "fastify-tsconfig": "^1.0.1",

--- a/src/plugins/env.ts
+++ b/src/plugins/env.ts
@@ -1,5 +1,5 @@
-import fp from "fastify-plugin";
 import fastifyEnv from "@fastify/env";
+import fp from "fastify-plugin";
 
 const schema = {
   type: "object",
@@ -18,6 +18,7 @@ export default fp(async (fastify, opts) => {
   const options = {
     ...opts,
     schema,
+    dotenv: true,
   };
 
   fastify.register(fastifyEnv, options);

--- a/src/routes/coingeckoProxy/index.ts
+++ b/src/routes/coingeckoProxy/index.ts
@@ -1,0 +1,22 @@
+import httpProxy from "@fastify/http-proxy";
+import { FastifyPluginAsync } from "fastify";
+
+const coingeckoProxy: FastifyPluginAsync = async (
+  fastify,
+  opts
+): Promise<void> => {
+  fastify.register(httpProxy, {
+    upstream: "https://api.coingecko.com",
+    rewritePrefix: "/api/v3/simple/",
+    replyOptions: {
+      rewriteRequestHeaders: (originalRequest: any, headers: any) => {
+        return {
+          ...headers,
+          Origin: "https://swap.cow.fi",
+        };
+      },
+    },
+  });
+};
+
+export default coingeckoProxy;

--- a/src/routes/coingeckoProxy/index.ts
+++ b/src/routes/coingeckoProxy/index.ts
@@ -1,10 +1,82 @@
+import fastifyCaching from "@fastify/caching";
 import httpProxy from "@fastify/http-proxy";
 import { FastifyPluginAsync } from "fastify";
+import { ReadableStream } from "stream/web";
+
+const CACHE_TTL = 5 * 60 * 1000; // 5 min in ms
+
+type CachedData = {
+  item: {
+    contents: string;
+    headers: Headers;
+  };
+};
+
+function isCachedResponse(cached: any): cached is CachedData {
+  return (
+    cached &&
+    typeof cached === "object" &&
+    "item" in cached &&
+    typeof cached.item === "object" &&
+    "contents" in cached.item
+  );
+}
 
 const coingeckoProxy: FastifyPluginAsync = async (
   fastify,
   opts
 ): Promise<void> => {
+  // Set up caching
+  fastify.register(fastifyCaching, { expiresIn: 300, serverExpiresIn: 300 });
+
+  // Intercepts request and uses cache if found
+  fastify.addHook("onRequest", async function (req, reply) {
+    fastify.log.info("onRequest handler triggered");
+    fastify.cache.get(req.url.toLowerCase(), (err, result) => {
+      if (err) {
+        fastify.log.warn(`Error fetching cache for '${req.url}'`, err);
+        return err;
+      }
+      if (isCachedResponse(result)) {
+        fastify.log.info("cache hit!!");
+        reply
+          .headers({ "cache-hit": true, ...result.item.headers })
+          .send(result.item.contents);
+      }
+    });
+  });
+
+  // Intercepts response to store result on cache
+  fastify.addHook("onSend", async function (req, reply, payload) {
+    if (reply.getHeader("cache-hit")) {
+      // Header set when there's a cache hit, remove it
+      reply.removeHeader("cache-hit");
+      fastify.log.info("cache hit, not storing it");
+    } else {
+      // No cache hit, consume the payload stream to be able to cache it
+      fastify.log.info("not cached, storing it");
+      let contents = "";
+      for await (const chunk of payload as ReadableStream) {
+        contents += chunk.toString(); // Process each chunk of data
+      }
+
+      // Cache contents and headers
+      fastify.cache.set(
+        req.url.toLowerCase(),
+        { contents, headers: reply.getHeaders() },
+        CACHE_TTL,
+        (error) => {
+          if (error)
+            fastify.log.error(`Failed to cache result for ${req.url}`, error);
+        }
+      );
+
+      // Return consumed payload
+      // This is important!!! Without this, the response will be empty
+      return contents;
+    }
+  });
+
   fastify.register(httpProxy, {
     upstream: "https://api.coingecko.com",
     rewritePrefix: "/api/v3/simple/",


### PR DESCRIPTION
# Summary

Add coingeckoProxy api endpoint

- Simple proxy for coingecko api
- In memory caching of requests

# Testing

- Run the server locally with `npm run dev`
- In another terminal, query the endpoint. Sample request:
```
curl -D - --request GET \
     --url 'http://localhost:3000/api/serverless/coingeckoProxy/token_price/ethereum?contract_addresses=0x035dF12E0F3ac6671126525f1015E47D79dFEDDF&vs_currencies=usd' \
     --header 'accept: application/json'
```
Client:

![image](https://github.com/cowprotocol/bff/assets/43217/1a4fb4da-a8aa-4dd1-a516-e231bc3fbd31)

Server:

![image](https://github.com/cowprotocol/bff/assets/43217/3498828c-213a-493b-8208-5962c5587cc8)
