### PR TITLE
feat: coingecko proxy without server side caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@fastify/autoload": "^5.0.0",
-        "@fastify/caching": "^8.3.0",
         "@fastify/cors": "^8.2.1",
         "@fastify/env": "^4.2.0",
         "@fastify/http-proxy": "^9.0.0",
@@ -628,16 +627,6 @@
       "license": "MIT",
       "dependencies": {
         "pkg-up": "^3.1.0"
-      }
-    },
-    "node_modules/@fastify/caching": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@fastify/caching/-/caching-8.3.0.tgz",
-      "integrity": "sha512-wxlQS2C9omy7+Aq33XDaHJWO0wF3DH2QFBD/ZHMJnWbL2buUDsjzCNg0TbSbEMHyFi/NiryYYAXVCoFCD7nFTA==",
-      "dependencies": {
-        "abstract-cache": "^1.0.1",
-        "fastify-plugin": "^4.0.0",
-        "uid-safe": "^2.1.5"
       }
     },
     "node_modules/@fastify/cors": {
@@ -1326,16 +1315,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/abstract-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/abstract-cache/-/abstract-cache-1.0.1.tgz",
-      "integrity": "sha512-EfUeMhRUbG5bVVbrSY/ogLlFXoyfMAPxMlSP7wrEqH53d+59r2foVy9a5KjmprLKFLOfPQCNKEfpBN/nQ76chw==",
-      "dependencies": {
-        "clone": "^2.1.1",
-        "lru_map": "^0.3.3",
-        "merge-options": "^1.0.0"
-      }
-    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "license": "MIT"
@@ -1827,14 +1806,6 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/close-with-grace": {
       "version": "1.1.0",
@@ -2635,14 +2606,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -3479,11 +3442,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "license": "ISC",
@@ -3537,17 +3495,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/merge-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
-      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
-      "dependencies": {
-        "is-plain-obj": "^1.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/merge-stream": {
@@ -4024,14 +3971,6 @@
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "license": "MIT"
-    },
-    "node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/react-is": {
       "version": "18.2.0",
@@ -4626,17 +4565,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "dependencies": {
-        "random-bytes": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "license": "ISC",
   "dependencies": {
     "@fastify/autoload": "^5.0.0",
-    "@fastify/caching": "^8.3.0",
     "@fastify/cors": "^8.2.1",
     "@fastify/env": "^4.2.0",
     "@fastify/http-proxy": "^9.0.0",

--- a/src/plugins/env.ts
+++ b/src/plugins/env.ts
@@ -3,12 +3,18 @@ import fp from "fastify-plugin";
 
 const schema = {
   type: "object",
-  required: ["PROXY_ORIGIN", "PROXY_UPSTREAM"],
+  required: ["PROXY_ORIGIN", "PROXY_UPSTREAM", "COINGECKO_API_KEY"],
   properties: {
     PROXY_ORIGIN: {
       type: "string",
     },
     PROXY_UPSTREAM: {
+      type: "string",
+    },
+    COINGECKO_API_KEY: {
+      type: "string",
+    },
+    COINGECKO_PROXY_UPSTREAM: {
       type: "string",
     },
   },

--- a/src/routes/coingeckoProxy/index.ts
+++ b/src/routes/coingeckoProxy/index.ts
@@ -28,7 +28,7 @@ const coingeckoProxy: FastifyPluginAsync = async (
             ? {
                 "cache-control": `max-age=${CACHE_TTL}, public, s-maxage=${SERVER_CACHE_TTL}`,
                 // Add `cdn-cache-control` otherwise Vercel strips `s-maxage` from `cache-control`
-                "cdn-cache-control": `max-age${SERVER_CACHE_TTL}`,
+                "cdn-cache-control": `max-age=${SERVER_CACHE_TTL}`,
               }
             : undefined),
         };

--- a/src/routes/coingeckoProxy/index.ts
+++ b/src/routes/coingeckoProxy/index.ts
@@ -3,15 +3,22 @@ import { FastifyPluginAsync } from "fastify";
 
 const CACHE_TTL = 1 * 60; // 1 min in s
 const SERVER_CACHE_TTL = 1.5 * 60; // 1.5 min in s
+const DEFAULT_COINGECKO_PROXY_UPSTREAM = "https://api.coingecko.com";
 
 const coingeckoProxy: FastifyPluginAsync = async (
   fastify,
   opts
 ): Promise<void> => {
   fastify.register(httpProxy, {
-    upstream: "https://api.coingecko.com",
-    rewritePrefix: "/api/v3/simple/",
+    upstream:
+      fastify.config.COINGECKO_PROXY_UPSTREAM ||
+      DEFAULT_COINGECKO_PROXY_UPSTREAM,
+    rewritePrefix: "/api/v3/",
     replyOptions: {
+      rewriteRequestHeaders: (request, headers) => ({
+        ...headers,
+        "x-cg-pro-api-key": fastify.config.COINGECKO_API_KEY,
+      }),
       // Response headers https://github.com/fastify/fastify-reply-from?tab=readme-ov-file#rewriteheadersheaders-request
       rewriteHeaders: (originalHeaders, request) => {
         const {

--- a/src/routes/coingeckoProxy/index.ts
+++ b/src/routes/coingeckoProxy/index.ts
@@ -34,6 +34,9 @@ const coingeckoProxy: FastifyPluginAsync = async (
         };
       },
     },
+    undici: {
+      strictContentLength: false, // Prevent errors when content-length header mismatches
+    },
   });
 };
 


### PR DESCRIPTION
# Summary

Different attempt at coingecko proxy.
Relying solely on Vercel CDN for caching, without the server side caching introduced on https://github.com/cowprotocol/bff/pull/10