### PR TITLE
Add platforms

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,7 @@ jobs:
           tags: ${{ steps.image_meta_bff-core.outputs.tags }}
           labels: ${{ steps.image_meta_bff-core.outputs.labels }}
           builder: ${{ steps.setup-buildx.outputs.name }}
+          platforms: linux/amd64
 
       - name: Image metadata
         id: image_meta_bff-twap
@@ -60,3 +61,4 @@ jobs:
           tags: ${{ steps.image_meta_bff-twap.outputs.tags }}
           labels: ${{ steps.image_meta_bff-twap.outputs.labels }}
           builder: ${{ steps.setup-buildx.outputs.name }}
+          platforms: linux/amd64


### PR DESCRIPTION
Tries to fix this issue:

❯ docker pull ghcr.io/cowprotocol/bff/core:latest
latest: Pulling from cowprotocol/bff/core
no matching manifest for linux/arm64/v8 in the manifest list entries