### PR TITLE
Improve pub subs

### DIFF
--- a/apps/notification-producer/src/main.ts
+++ b/apps/notification-producer/src/main.ts
@@ -12,7 +12,7 @@ import {
 } from '@cowprotocol/notifications';
 import Mustache from 'mustache';
 
-const WAIT_TIME = 3000;
+const WAIT_TIME = 30000;
 
 /**
  * This in-memory state just adds some resilience in case there's an error posting the message.

--- a/apps/notification-producer/src/postToQueueTest.ts
+++ b/apps/notification-producer/src/postToQueueTest.ts
@@ -5,7 +5,7 @@ import {
 } from '@cowprotocol/notifications';
 
 export async function main() {
-  const channel = await connectToChannel({
+  const { channel } = await connectToChannel({
     channel: NOTIFICATIONS_QUEUE,
   });
 

--- a/apps/telegram/src/main.ts
+++ b/apps/telegram/src/main.ts
@@ -13,10 +13,11 @@ import { Channel, ConsumeMessage } from 'amqplib';
 import assert from 'assert';
 import TelegramBot from 'node-telegram-bot-api';
 
-const WAIT_TIME = 10000;
+const WAIT_TIME = 10000; // 10s
+const SUBSCRIPTION_CACHE_TiME = 5 * 60 * 1000; // 5 minute
+
 const SUBSCRIPTION_CACHE = new Map<string, CmsTelegramSubscription[]>();
 const LAST_SUBSCRIPTION_CHECK = new Map<string, Date>();
-const SUBSCRIPTION_CHECK_FREQUENCY = 5 * 60 * 1000; // 5 minute
 
 let telegramBot: TelegramBot;
 
@@ -38,7 +39,7 @@ async function getSubscriptions(
   const lastCheck = LAST_SUBSCRIPTION_CHECK.get(account);
   if (
     !lastCheck ||
-    lastCheck.getTime() + SUBSCRIPTION_CHECK_FREQUENCY < Date.now()
+    lastCheck.getTime() + SUBSCRIPTION_CACHE_TiME < Date.now()
   ) {
     // Get the subscriptions for this account (if we haven't checked in a while)
     const subscriptionForAccount = await getAllTelegramSubscriptionsForAccounts(

--- a/apps/telegram/src/main.ts
+++ b/apps/telegram/src/main.ts
@@ -7,69 +7,132 @@ import {
   Notification,
   connectToChannel,
   parseNotification,
+  sleep,
 } from '@cowprotocol/notifications';
+import { Channel, ConsumeMessage } from 'amqplib';
 import assert from 'assert';
 import TelegramBot from 'node-telegram-bot-api';
 
-const SLEEP_TIME = 5000;
+const WAIT_TIME = 10000;
 const SUBSCRIPTION_CACHE = new Map<string, CmsTelegramSubscription[]>();
+const LAST_SUBSCRIPTION_CHECK = new Map<string, Date>();
+const SUBSCRIPTION_CHECK_FREQUENCY = 5 * 60 * 1000; // 5 minute
+
+let telegramBot: TelegramBot;
 
 // Create telegram bot
-const token = process.env.TELEGRAM_SECRET;
-assert(token, 'TELEGRAM_SECRET is required');
-const telegramBot = new TelegramBot(token, { polling: true });
+function createTelegramBot() {
+  if (!telegramBot) {
+    const token = process.env.TELEGRAM_SECRET;
+    assert(token, 'TELEGRAM_SECRET is required');
+    telegramBot = new TelegramBot(token, { polling: true });
+  }
 
-async function main() {
-  const channel = await connectToChannel({
+  return telegramBot;
+}
+
+async function getSubscriptions(
+  account: string
+): Promise<CmsTelegramSubscription[]> {
+  // Get the subscriptions for this account
+  const lastCheck = LAST_SUBSCRIPTION_CHECK.get(account);
+  if (
+    !lastCheck ||
+    lastCheck.getTime() + SUBSCRIPTION_CHECK_FREQUENCY < Date.now()
+  ) {
+    // Get the subscriptions for this account (if we haven't checked in a while)
+    const subscriptionForAccount = await getAllTelegramSubscriptionsForAccounts(
+      [account]
+    );
+    SUBSCRIPTION_CACHE.set(account, subscriptionForAccount);
+  }
+
+  return SUBSCRIPTION_CACHE.get(account) || [];
+}
+
+async function onNewMessage(channel: Channel, msg: ConsumeMessage) {
+  const notification = parseNotification(msg.content.toString());
+  const { id, message, account, title, url } = notification;
+  console.debug(
+    `[telegram:main] New Notification ${id} for ${account}. ${title}: ${message}. URL=${url}`
+  );
+
+  // Get the subscriptions for this account
+  const telegramSubscriptions = await getSubscriptions(account);
+
+  let consumeMessage = false;
+  try {
+    if (telegramSubscriptions.length > 0) {
+      // Send the message to all subscribers
+      for (const { chat_id: chatId } of telegramSubscriptions) {
+        console.debug(
+          `[telegram:main] Sending message ${id} to chatId ${chatId}`
+        );
+        telegramBot.sendMessage(chatId, formatMessage(notification));
+
+        // Acknowledge the message once its been sent to at least one subscriber for this account
+        consumeMessage = true;
+      }
+    } else {
+      // No telegram subscriptions found for this account
+      consumeMessage = true;
+      console.debug(
+        `[telegram:main] No subscriptions found for account ${account}`
+      );
+    }
+  } finally {
+    if (consumeMessage) {
+      channel.ack(msg);
+    } else {
+      channel.nack(msg);
+    }
+  }
+}
+
+async function connect() {
+  const { connection, channel } = await connectToChannel({
     channel: NOTIFICATIONS_QUEUE,
   });
+  channel.assertQueue(NOTIFICATIONS_QUEUE, { durable: false });
 
-  // This makes sure the queue is declared
-  channel.assertQueue(NOTIFICATIONS_QUEUE, {
-    durable: false,
-  });
-
-  console.log(
-    '[telegram-consumer] Waiting for messages in %s',
-    NOTIFICATIONS_QUEUE
+  console.info(
+    `[telegram:main] Waiting for messages in "${NOTIFICATIONS_QUEUE}" queue`
   );
-
-  // Consume messages from RabbitMQ
-  channel.consume(
+  await channel.consume(
     NOTIFICATIONS_QUEUE,
-    async function (msg) {
-      const notification = parseNotification(msg.content.toString());
-      const { id, message, account, title, url } = notification;
-      console.log(
-        `[telegram-consumer] New Notification ${id} for ${account}. ${title}: ${message}. URL=${url}`
-      );
-
-      // TODO: Don't check every time!!
-      // Check in CMS if there's one
-      const subscriptionForAccount =
-        await getAllTelegramSubscriptionsForAccounts([account]);
-
-      SUBSCRIPTION_CACHE.set(account, subscriptionForAccount);
-
-      const telegramSubscriptions = SUBSCRIPTION_CACHE.get(account);
-      if (telegramSubscriptions.length > 0) {
-        // Send the message to all subscribers
-        for (const { chat_id: chatId } of telegramSubscriptions) {
-          console.log(
-            `[telegram-consumer] Sending message ${id} to chatId ${chatId}`
-          );
-          telegramBot.sendMessage(chatId, formatMessage(notification));
-        }
-      } else {
-        console.log(
-          `[telegram-consumer] No subscriptions found for account ${account}`
-        );
-      }
-    },
+    async (msg) => onNewMessage(channel, msg),
     {
-      noAck: true,
+      noAck: false,
     }
   );
+
+  return { connection, channel };
+}
+
+/**
+ * Connect to RabbitMQ and listen for messages. It will post them to Telegram when they belong to a subscribed account.
+ *
+ * This function will not resolved until the connection is closed or an error occurs.
+ */
+async function main() {
+  telegramBot = createTelegramBot();
+  const { connection } = await connect();
+
+  // Watch for connection close
+  let connectionOpen = true;
+  connection.on('close', () => {
+    console.error(
+      `[telegram:main] Queue connection closed! Reconnecting in ${
+        WAIT_TIME / 1000
+      }s`
+    );
+    connectionOpen = false;
+  });
+
+  // Wait while we have an open connection
+  while (connectionOpen) {
+    await sleep(WAIT_TIME);
+  }
 }
 
 function formatMessage({ title, message, url }: Notification) {
@@ -87,13 +150,19 @@ More info in ${url}`
 }`;
 }
 
-async function logErrorAndReconnect(error): Promise<void> {
-  console.error('[telegram] Error ', error);
-  console.log(
-    `[notification-producer] Reconnecting in ${SLEEP_TIME / 1000}s...`
-  );
-  return main().catch(logErrorAndReconnect);
+async function mainLoop() {
+  // Main loop: Run and re-attempt on error
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      await main();
+    } catch (error) {
+      console.error('[telegram:main] Error', error);
+      console.info(`[telegram:main] Reconnecting in ${WAIT_TIME / 1000}s...`);
+    } finally {
+      await sleep(WAIT_TIME);
+    }
+  }
 }
 
-// Start the main function
-main().catch(logErrorAndReconnect);
+mainLoop();

--- a/apps/telegram/src/main.ts
+++ b/apps/telegram/src/main.ts
@@ -93,7 +93,6 @@ async function connect() {
   const { connection, channel } = await connectToChannel({
     channel: NOTIFICATIONS_QUEUE,
   });
-  channel.assertQueue(NOTIFICATIONS_QUEUE, { durable: false });
 
   console.info(
     `[telegram:main] Waiting for messages in "${NOTIFICATIONS_QUEUE}" queue`
@@ -150,8 +149,11 @@ More info in ${url}`
 }`;
 }
 
+/**
+ * Main loop: Run and re-attempt on error
+ */
 async function mainLoop() {
-  // Main loop: Run and re-attempt on error
+  console.info('[telegram:main] Start telegram consumer');
   // eslint-disable-next-line no-constant-condition
   while (true) {
     try {

--- a/libs/cms-api/src/index.ts
+++ b/libs/cms-api/src/index.ts
@@ -27,6 +27,17 @@ export type CmsPushNotification = {
   };
 };
 
+// TODO: For now the CMS don't generate this type. Adding it manually for now.
+export interface NotificationModel {
+  id: number;
+  account: string;
+  title: string;
+  description: string;
+  createdAt: string;
+  url: string | null;
+  thumbnail: string | null;
+}
+
 const cmsBaseUrl = process.env.CMS_BASE_URL;
 assert(cmsBaseUrl, 'CMS_BASE_URL is required');
 const cmsApiKey = process.env.CMS_API_KEY;
@@ -38,6 +49,26 @@ const cmsClient = CmsClient({
 });
 
 const PAGE_SIZE = 50;
+
+export async function getNotificationsByAccount({
+  account,
+}: {
+  account: string;
+}): Promise<NotificationModel[]> {
+  const { data, error, response } = await cmsClient.GET(
+    '/notification-list/' + account
+  );
+
+  if (error) {
+    console.error(
+      `Error ${response.status} getting notifications: ${response.url}`,
+      error
+    );
+    throw error;
+  }
+
+  return data.data;
+}
 
 export async function getAllNotifications(): Promise<CmsNotification[]> {
   const allNotifications = [];

--- a/libs/notifications/src/index.ts
+++ b/libs/notifications/src/index.ts
@@ -1,4 +1,4 @@
-import amqp, { Channel } from 'amqplib';
+import amqp, { Channel, Connection } from 'amqplib';
 import assert from 'assert';
 
 export const NOTIFICATIONS_QUEUE = 'notifications';
@@ -33,16 +33,20 @@ export function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-interface ConnectToQueueParams {
+export interface ConnectToQueueParams {
   channel?: string;
+}
+
+export interface ConnectToChannelResponse {
+  connection: Connection;
+  channel: Channel;
 }
 
 export async function connectToChannel(
   params: ConnectToQueueParams
-): Promise<Channel> {
+): Promise<ConnectToChannelResponse> {
   // Connect to RabbitMQ server
   const { channel: channelName } = params;
-  console.log('[notifications] Fetching notifications');
 
   const connection = await amqp.connect({
     hostname: queueHost,
@@ -60,7 +64,7 @@ export async function connectToChannel(
     });
   }
 
-  return channel;
+  return { connection, channel };
 }
 
 export interface SendToQueueParams {


### PR DESCRIPTION
This PR fixes a bunch of issues related to the notifications publisher and consumer

Publisher
- Fixed main loop, it was not working as expected
- Keep connection alive, handle closing of the queue
- Handle error posting the message (tries to re-attempt later when the connection is established). Before it was loosing the message. Still needs improvement, but requires an API change
- Generaral refactors and logging improvements
- Recover from errors

Consumer
- Fixed main loop, it was not working as expected
- Keep connection alive, handle closing of the queue
- Generaral refactors and logging improvements
- Recover from errors

## Test
- start queue with docker
- start producer with NX
- start consumer with NX
- Add a notification in the CMS


You can try to see how if we kill the queue, both services notice it, and will periodically re-attempt to connect