### PR TITLE
Improve project config

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -43,7 +43,7 @@
         }
       }
     },
-    "serve": {
+    "start": {
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
       "options": {

--- a/apps/notification-producer/project.json
+++ b/apps/notification-producer/project.json
@@ -32,6 +32,9 @@
       },
       "configurations": {
         "development": {},
+        "postToQueueTest": {
+          "main": "apps/notification-producer/src/postToQueueTest.ts"
+        },
         "production": {
           "generateLockfile": true,
           "esbuildOptions": {
@@ -43,7 +46,7 @@
         }
       }
     },
-    "serve": {
+    "start": {
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
       "options": {
@@ -53,9 +56,22 @@
         "development": {
           "buildTarget": "notification-producer:build:development"
         },
+        "postToQueueTest": {
+          "buildTarget": "notification-producer:build:postToQueueTest",
+          "main": "apps/notification-producer/src/postToQueueTest.js"
+        },
         "production": {
           "buildTarget": "notification-producer:build:production"
         }
+      }
+    },
+    "tsc": {
+      "executor": "@nx/js:tsc",
+      "options": {
+        "outputPath": "dist/apps/notification-producer",
+        "main": "apps/notification-producer/src/postToQueueTest.ts",
+        "tsConfig": "apps/notification-producer/tsconfig.app.json",
+        "rootDir": "../.."
       }
     },
     "lint": {
@@ -83,12 +99,6 @@
           "ci": true,
           "codeCoverage": true
         }
-      }
-    },
-    "postToQueueTest": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "npx ts-node apps/notification-producer/src/postToQueueTest"
       }
     },
     "docker-build": {

--- a/apps/telegram/project.json
+++ b/apps/telegram/project.json
@@ -6,16 +6,22 @@
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "defaultConfiguration": "production",
       "options": {
         "platform": "node",
         "outputPath": "dist/apps/telegram",
-        "format": ["cjs"],
+        "format": [
+          "cjs"
+        ],
         "bundle": false,
         "main": "apps/telegram/src/main.ts",
         "tsConfig": "apps/telegram/tsconfig.app.json",
-        "assets": ["apps/telegram/src/assets"],
+        "assets": [
+          "apps/telegram/src/assets"
+        ],
         "generatePackageJson": true,
         "esbuildOptions": {
           "sourcemap": true,
@@ -37,7 +43,7 @@
         }
       }
     },
-    "serve": {
+    "start": {
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
       "options": {
@@ -54,14 +60,20 @@
     },
     "lint": {
       "executor": "@nx/linter:eslint",
-      "outputs": ["{options.outputFile}"],
+      "outputs": [
+        "{options.outputFile}"
+      ],
       "options": {
-        "lintFilePatterns": ["apps/telegram/**/*.ts"]
+        "lintFilePatterns": [
+          "apps/telegram/**/*.ts"
+        ]
       }
     },
     "test": {
       "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "outputs": [
+        "{workspaceRoot}/coverage/{projectRoot}"
+      ],
       "options": {
         "jestConfig": "apps/telegram/jest.config.ts",
         "passWithNoTests": true
@@ -74,7 +86,9 @@
       }
     },
     "docker-build": {
-      "dependsOn": ["build"],
+      "dependsOn": [
+        "build"
+      ],
       "command": "docker build -f apps/telegram/Dockerfile . -t telegram"
     }
   },

--- a/apps/twap/project.json
+++ b/apps/twap/project.json
@@ -43,7 +43,7 @@
         }
       }
     },
-    "serve": {
+    "start": {
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
       "options": {

--- a/package.json
+++ b/package.json
@@ -3,17 +3,18 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
+    "start": "yarn start:api",
+    "start:api": "nx start",
     "twap:run-migrations": "nx run twap:run-migrations",
     "twap:generate-migrations": "nx run twap:generate-migrations",
-    "producer": "nx run notification-producer:serve",
-    "telegram": "nx run telegram:serve",
-    "serve": "nx serve",
+    "producer": "nx run notification-producer:start",
+    "telegram": "nx run telegram:start",
     "build": "nx run-many --all --target=build",
     "new:fastify": "nx generate @nx/node:application --framework=fastify --docker --directory=apps",
     "new:node": "nx generate @nx/node:application --directory=apps --docker",
     "new:lib": "nx g @nx/node:library --directory=libs",
     "docker-build:affected": "nx affected -t docker-build --prod --parallel --maxParallel=3 --skip-nx-cache --skip-nx-cache",
-    "compose:up": "yarn run docker-build:affected && docker-compose up"
+    "compose:up": "yarn docker-build:affected && docker-compose up"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This PR just use our convention `start` instead of `serve` to run a service

Modifies the API, telegram, and producer so now you can run them with `start` 