### PR TITLE
feat: expose notifications api

### DIFF
--- a/apps/api/src/app/routes/accounts/_account/notifications/index.ts
+++ b/apps/api/src/app/routes/accounts/_account/notifications/index.ts
@@ -1,0 +1,36 @@
+import {
+  NotificationModel,
+  getNotificationsByAccount,
+} from '@cowprotocol/cms-api';
+import { FastifyPluginAsync } from 'fastify';
+import { FromSchema, JSONSchema } from 'json-schema-to-ts';
+
+const routeSchema = {
+  type: 'object',
+  required: ['account'],
+  properties: {
+    account: {
+      title: 'account',
+      description: 'Account of the user',
+      type: 'string',
+    },
+  },
+} as const satisfies JSONSchema;
+type RouteSchema = FromSchema<typeof routeSchema>;
+
+type GetNotificationsSchema = RouteSchema;
+
+const accounts: FastifyPluginAsync = async (fastify): Promise<void> => {
+  // GET /accounts/:account/notifications
+  fastify.get<{
+    Params: GetNotificationsSchema;
+    Reply: NotificationModel[];
+  }>('/', { schema: { params: routeSchema } }, async function (request, reply) {
+    const account = request.params.account;
+    const notifications = await getNotificationsByAccount({ account });
+    reply.status(200).send(notifications);
+    return reply.send(notifications);
+  });
+};
+
+export default accounts;


### PR DESCRIPTION
WIP

Expose the notifications using BFF

This way, we can aggregate notifications from multiple sources, including CMS, release notes, our DB (populated by events, etc)