### PR TITLE
Expose commit hash and version in the about service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Version: Used in the /about endpoint. Useful to expose the Docker image version.
+VESION=1.0.0
+
 # Port
 PORT=8080
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
+      
+      - name: Write commit hash
+        run: echo "${{ github.sha }}" > git-commit-hash.env
+        
       - run: yarn build
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
       - run: yarn install
       
       - name: Write commit hash
-        run: echo "${{ github.sha }}" > git-commit-hash.env
+        run: echo "${{ github.sha }}" > dist/git-commit-hash.txt
         
       - run: yarn build
 

--- a/apps/api/src/app/routes/about/index.ts
+++ b/apps/api/src/app/routes/about/index.ts
@@ -1,18 +1,39 @@
+import { log } from 'console';
 import { FastifyPluginAsync } from 'fastify';
-import { version } from '../../../../../../package.json';
+
+import { readFileSync } from 'fs';
+const GIT_COMMIT_HASH_FILE = '.git-commit-hash';
+const VERSION = process.env.VERSION || 'UNKNOWN, please set the environment variable';
+const COMMIT_HASH = getCommitHash();
+
 
 interface AboutResponse {
   name: string;
   version: string;
+  commitHash?: string | undefined;
 }
 
 const example: FastifyPluginAsync = async (fastify): Promise<void> => {
   fastify.get<{ Reply: AboutResponse }>('/', async function (_request, reply) {
     return reply.send({
       name: 'BFF API',
-      version,
+      version: VERSION,
+      commitHash: COMMIT_HASH,
     });
   });
 };
+
+/**
+ * Read a file with the git commit hash (generated for example using github actions)
+ */
+function getCommitHash(): string | undefined {
+  try {
+    return readFileSync(GIT_COMMIT_HASH_FILE, 'utf-8')
+  } catch (error) {
+    // Not a big deal, if the file is not present, the about won't 
+    console.warn(`Unable to read the commit hash file: ${GIT_COMMIT_HASH_FILE}. It won't be exported in the about section`);  
+    return undefined
+  }
+}
 
 export default example;

--- a/apps/api/src/app/routes/about/index.ts
+++ b/apps/api/src/app/routes/about/index.ts
@@ -2,15 +2,17 @@ import { log } from 'console';
 import { FastifyPluginAsync } from 'fastify';
 
 import { readFileSync } from 'fs';
-const GIT_COMMIT_HASH_FILE = '.git-commit-hash';
+const GIT_COMMIT_HASH_FILE = 'git-commit-hash.txt';
 const VERSION = process.env.VERSION || 'UNKNOWN, please set the environment variable';
 const COMMIT_HASH = getCommitHash();
+import { join } from 'path';
+
 
 
 interface AboutResponse {
   name: string;
   version: string;
-  commitHash?: string | undefined;
+  gitCommitHash?: string | undefined;
 }
 
 const example: FastifyPluginAsync = async (fastify): Promise<void> => {
@@ -18,7 +20,7 @@ const example: FastifyPluginAsync = async (fastify): Promise<void> => {
     return reply.send({
       name: 'BFF API',
       version: VERSION,
-      commitHash: COMMIT_HASH,
+      gitCommitHash: COMMIT_HASH,
     });
   });
 };
@@ -27,11 +29,12 @@ const example: FastifyPluginAsync = async (fastify): Promise<void> => {
  * Read a file with the git commit hash (generated for example using github actions)
  */
 function getCommitHash(): string | undefined {
-  try {
-    return readFileSync(GIT_COMMIT_HASH_FILE, 'utf-8')
+  const filePath = join(__dirname, '../../../../../../../../', GIT_COMMIT_HASH_FILE)
+  try {    
+    return readFileSync(filePath, 'utf-8')
   } catch (error) {
     // Not a big deal, if the file is not present, the about won't 
-    console.warn(`Unable to read the commit hash file: ${GIT_COMMIT_HASH_FILE}. It won't be exported in the about section`);  
+    console.warn(`Unable to read the commit hash file ${filePath}, therefore won't be exported in the about endpoint`);  
     return undefined
   }
 }


### PR DESCRIPTION
This PR is an attempt to allow us to see in any service what is the version we are running and what commit.

I added one additional step in the build that writes a text file with the git commit hash. 
This file is then read by the `/about` endpoint, which if present it will expose this hash

