### PR TITLE
Dont include line break in version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
       - run: yarn install
 
       - name: Write commit hash in the assets directory
-        run: echo "${{ github.sha }}" > assets/git-commit-hash.txt
+        run: echo -n "${{ github.sha }}" > assets/git-commit-hash.txt
         
       - run: yarn build
 


### PR DESCRIPTION
This PR deletes a line break that was added into the version file:

![image](https://github.com/cowprotocol/bff/assets/2352112/6a046db3-7e44-4b35-b2e9-4b0e3ef742b5)
