### PR TITLE
Auto-deploy to staging when merging in main branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,3 +59,13 @@ jobs:
           labels: ${{ steps.image_meta.outputs.labels }}
           builder: ${{ steps.setup-buildx.outputs.name }}
           platforms: linux/amd64
+
+
+      - uses: cowprotocol/autodeploy-action@v2
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          images: ghcr.io/cowprotocol/bff/${{ env.PACKAGE_NAME }}:main
+          tag: ${{ secrets.AUTODEPLOY_TAG }}
+          url: ${{ secrets.AUTODEPLOY_URL }}
+          token: ${{ secrets.AUTODEPLOY_TOKEN }}
+          timeout: 600000 # 10 minutes

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,6 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           images: ghcr.io/cowprotocol/bff/${{ env.PACKAGE_NAME }}:main
-          tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}
           timeout: 600000 # 10 minutes


### PR DESCRIPTION
This PR adds the auto-deployment to staging. 

Every time a PR is merged with `main`, it will notify the auto-deployer so it can restart the services that depend on the newly generated images.

Because of the image pull policy, the restart will pull and use the new images


## Before merging
@ahhda, I think we need to set this secrets, but I'm unsure about the value. 
~secrets.AUTODEPLOY_TAG~ (edit: not needed)
secrets.AUTODEPLOY_URL
secrets.AUTODEPLOY_TOKEN

I guess the URL is what i see in 1password in "K8S autodeploy auth", the token I assume is the "password". What is the TAG? 