### PR TITLE
feat: expose notifications api

### DIFF
--- a/apps/api/src/app/routes/__chainId/markets/__baseTokenAddress-__quoteTokenAddress/slippageTolerance.ts
+++ b/apps/api/src/app/routes/__chainId/markets/__baseTokenAddress-__quoteTokenAddress/slippageTolerance.ts
@@ -7,7 +7,6 @@ import {
   CACHE_CONTROL_HEADER,
   getCacheControlHeaderValue,
 } from '../../../../../utils/cache';
-import { deprecate } from 'util';
 
 const CACHE_SECONDS = 120;
 
@@ -31,6 +30,7 @@ const routeSchema = {
     },
   },
 } as const satisfies JSONSchema;
+
 const successSchema = {
   type: 'object',
   required: ['slippageBps'],

--- a/apps/api/src/app/routes/accounts/_account/notifications.ts
+++ b/apps/api/src/app/routes/accounts/_account/notifications.ts
@@ -4,6 +4,7 @@ import {
 } from '@cowprotocol/cms-api';
 import { FastifyPluginAsync } from 'fastify';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
+import { ETHEREUM_ADDRESS_PATTERN } from '../../../schemas';
 
 const routeSchema = {
   type: 'object',
@@ -13,9 +14,11 @@ const routeSchema = {
       title: 'account',
       description: 'Account of the user',
       type: 'string',
+      pattern: ETHEREUM_ADDRESS_PATTERN,
     },
   },
 } as const satisfies JSONSchema;
+
 type RouteSchema = FromSchema<typeof routeSchema>;
 
 type GetNotificationsSchema = RouteSchema;
@@ -25,12 +28,15 @@ const accounts: FastifyPluginAsync = async (fastify): Promise<void> => {
   fastify.get<{
     Params: GetNotificationsSchema;
     Reply: NotificationModel[];
-  }>('/', { schema: { params: routeSchema } }, async function (request, reply) {
-    const account = request.params.account;
-    const notifications = await getNotificationsByAccount({ account });
-    reply.status(200).send(notifications);
-    return reply.send(notifications);
-  });
+  }>(
+    '/notifications',
+    { schema: { params: routeSchema } },
+    async function (request, reply) {
+      const account = request.params.account;
+      const notifications = await getNotificationsByAccount({ account });
+      reply.send([]);
+    }
+  );
 };
 
 export default accounts;

--- a/apps/api/src/app/routes/accounts/_account/notifications.ts
+++ b/apps/api/src/app/routes/accounts/_account/notifications.ts
@@ -34,7 +34,7 @@ const accounts: FastifyPluginAsync = async (fastify): Promise<void> => {
     async function (request, reply) {
       const account = request.params.account;
       const notifications = await getNotificationsByAccount({ account });
-      reply.send([]);
+      reply.send(notifications);
     }
   );
 };

--- a/apps/api/src/app/routes/accounts/_account/notifications/index.ts
+++ b/apps/api/src/app/routes/accounts/_account/notifications/index.ts
@@ -1,0 +1,36 @@
+import {
+  NotificationModel,
+  getNotificationsByAccount,
+} from '@cowprotocol/cms-api';
+import { FastifyPluginAsync } from 'fastify';
+import { FromSchema, JSONSchema } from 'json-schema-to-ts';
+
+const routeSchema = {
+  type: 'object',
+  required: ['account'],
+  properties: {
+    account: {
+      title: 'account',
+      description: 'Account of the user',
+      type: 'string',
+    },
+  },
+} as const satisfies JSONSchema;
+type RouteSchema = FromSchema<typeof routeSchema>;
+
+type GetNotificationsSchema = RouteSchema;
+
+const accounts: FastifyPluginAsync = async (fastify): Promise<void> => {
+  // GET /accounts/:account/notifications
+  fastify.get<{
+    Params: GetNotificationsSchema;
+    Reply: NotificationModel[];
+  }>('/', { schema: { params: routeSchema } }, async function (request, reply) {
+    const account = request.params.account;
+    const notifications = await getNotificationsByAccount({ account });
+    reply.status(200).send(notifications);
+    return reply.send(notifications);
+  });
+};
+
+export default accounts;

--- a/libs/cms-api/src/index.ts
+++ b/libs/cms-api/src/index.ts
@@ -67,7 +67,7 @@ export async function getNotificationsByAccount({
     throw error;
   }
 
-  return data.data;
+  return data;
 }
 
 export async function getAllNotifications(): Promise<CmsNotification[]> {


### PR DESCRIPTION
This PR exposes the notifications API in BFF.

<img width="1062" alt="image" src="https://github.com/user-attachments/assets/9064021a-3a65-4836-9e59-1558f202a447">

Right now the Nofications are coming from the CMS, but some notifications can be added to some other sources (like a database, etc), also the notifications can be enhanced with on-chain data, or post-processed, for this reason, I think is convenient to expose it through BFF.


This would also allow us to remove the dependency from CoW Swap to the CMS and reduce the permissions of reading the notifications from the public endpoint (now is a securitized request)


## Test
Run locally and execute:
`curl -i http://localhost:3010/accounts/0x79063d9173C09887d536924E2F6eADbaBAc099f5/notifications`