### PR TITLE
Hide some routes in swagger

### DIFF
--- a/apps/api/src/app/plugins/swagger.ts
+++ b/apps/api/src/app/plugins/swagger.ts
@@ -3,9 +3,21 @@ import fp from 'fastify-plugin';
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 
+const HIDDEN_PATHS = ['/'];
+const HIDDEN_BASE_PATHS = ['/proxies', '/proxy', '/twap'];
+
 export default fp(async function (fastify: FastifyInstance) {
   fastify.register(fastifySwagger, {
-    swagger: {},
+    swagger: {
+    },
+    transform: (param) => {
+      const { schema = {}, url } = param
+
+      // can add the hide tag if needed
+      const modifiedSchema = (isHiddenPath(url)) ? { ...schema, hide: true } : schema
+
+      return { ...param, schema: modifiedSchema }
+    }
   });
   fastify.register(fastifySwaggerUi, {
     routePrefix: '/docs',
@@ -14,4 +26,17 @@ export default fp(async function (fastify: FastifyInstance) {
     if (err) throw err;
     fastify.swagger();
   });
+
 });
+
+function isHiddenPath(url: string) {
+  if (HIDDEN_BASE_PATHS.some(basePath => url.startsWith(basePath))) {
+    return true;
+  }
+
+  if (HIDDEN_PATHS.some(basePath => url === basePath)) {
+    return true;
+  }
+
+  return false
+}

--- a/apps/api/src/app/routes/about.ts
+++ b/apps/api/src/app/routes/about.ts
@@ -16,7 +16,7 @@ interface AboutResponse {
 }
 
 const example: FastifyPluginAsync = async (fastify): Promise<void> => {
-  fastify.get<{ Reply: AboutResponse }>('/', async function (_request, reply) {
+  fastify.get<{ Reply: AboutResponse }>('/about', async function (_request, reply) {
     return reply.send({
       name: 'BFF API',
       version: VERSION,
@@ -29,12 +29,12 @@ const example: FastifyPluginAsync = async (fastify): Promise<void> => {
  * Read a file with the git commit hash (generated for example using github actions)
  */
 function getCommitHash(): string | undefined {
-  const filePath = join(__dirname, '../../..', GIT_COMMIT_HASH_FILE)
-  try {    
+  const filePath = join(__dirname, '../..', GIT_COMMIT_HASH_FILE)
+  try {
     return readFileSync(filePath, 'utf-8')
   } catch (error) {
     // Not a big deal, if the file is not present, the about won't 
-    console.warn(`Unable to read the commit hash file ${filePath}, therefore won't be exported in the about endpoint`);  
+    console.warn(`Unable to read the file with the git commit hash: ${filePath}. /about endpoint won't export the 'gitCommitHash'`);
     return undefined
   }
 }


### PR DESCRIPTION
Hide some routes in swagger

## Test

Run locally, check the new swagger docs, you should only see the `/about` endpoint
<img width="1145" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/4712e307-205e-4950-84b0-f2f6218b8930">

Check the old one, you should see a lot of stuff you don't want to see:
https://bff.barn.cow.fi/docs/static/index.html

<img width="454" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/941764a0-6c7c-4498-a420-de1b91dc8926">
