### PR TITLE
Delete legacy proxy endpoint

### DIFF
--- a/apps/api/src/app/routes/proxy/index.ts
+++ b/apps/api/src/app/routes/proxy/index.ts
@@ -1,5 +1,0 @@
-import tokensProxy from "../proxies/tokens";
-
-// TODO: temporarily re-export old path while we migrate deployed services
-// TODO: remove this path after 2 months: by 2024-07-01
-export default tokensProxy;


### PR DESCRIPTION
BFF is live, so we don't need anymore serveless functions from Vercel.

This PR deletes the legacy proxy