### PR TITLE
Misc on improving debugability and making sure CACHEs work

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     tags: [v*]
 
+  pull_request:
+    types: [opened, synchronize]
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
 
       - name: Write commit hash in the assets directory
         run: echo -n "${{ github.sha }}" > assets/git-commit-hash.txt
-        
+
       - run: yarn build
 
       - name: Set up Docker Buildx
@@ -59,7 +62,6 @@ jobs:
           labels: ${{ steps.image_meta.outputs.labels }}
           builder: ${{ steps.setup-buildx.outputs.name }}
           platforms: linux/amd64
-
 
       - uses: cowprotocol/autodeploy-action@v2
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/apps/api/src/app/plugins/env.ts
+++ b/apps/api/src/app/plugins/env.ts
@@ -5,6 +5,9 @@ const schema = {
   type: "object",
   required: ["PROXY_ORIGIN", "PROXY_UPSTREAM", "COINGECKO_API_KEY"],
   properties: {
+    LOG_LEVEL: {
+      type: "string",
+    },
     PROXY_ORIGIN: {
       type: "string",
     },

--- a/apps/api/src/app/routes/proxies/coingecko/index.ts
+++ b/apps/api/src/app/routes/proxies/coingecko/index.ts
@@ -37,8 +37,8 @@ const coingeckoProxy: FastifyPluginAsync = async (
         });
 
         const logOptions = { url: request.url, method: request.method }
-        fastify.log.trace(logOptions, `Old Headers`);
-        fastify.log.trace(logOptions, `New Headers`);
+        fastify.log.trace(logOptions, `Old Headers: ${JSON.stringify(headers)}`);
+        fastify.log.trace(logOptions, `New Headers: ${JSON.stringify(newHeaders)}`);
 
         return newHeaders
 

--- a/apps/api/src/app/routes/proxies/coingecko/index.ts
+++ b/apps/api/src/app/routes/proxies/coingecko/index.ts
@@ -1,6 +1,8 @@
 import httpProxy from "@fastify/http-proxy";
 import { FastifyPluginAsync } from "fastify";
 
+const DROP_HEADERS = ['cf-ray', 'cf-cache-status', 'set-cookie', 'server']
+
 const CACHE_TTL = 1 * 60; // 1 min in s
 const SERVER_CACHE_TTL = 1.5 * 60; // 1.5 min in s
 const DEFAULT_COINGECKO_PROXY_UPSTREAM = "https://api.coingecko.com";
@@ -20,25 +22,22 @@ const coingeckoProxy: FastifyPluginAsync = async (
         "x-cg-pro-api-key": fastify.config.COINGECKO_API_KEY,
       }),
       // Response headers https://github.com/fastify/fastify-reply-from?tab=readme-ov-file#rewriteheadersheaders-request
-      rewriteHeaders: (originalHeaders, request) => {
-        const {
-          // Drop set-cookie header to allow Vercel CDN caching https://vercel.com/docs/edge-network/caching#cacheable-response-criteria
-          "set-cookie": _,
-          "cache-control": cacheControl,
-          ...headers
-        } = originalHeaders;
-
-        return {
+      rewriteHeaders: (headers, request) => {
+        // Drop some headers
+        const newHeaders = DROP_HEADERS.reduce((acc, header) => {
+          delete acc[header];
+          return acc;
+        }, {
           ...headers,
-          // Only replace `cache-control` if it was set in the response
-          ...(cacheControl
+          ...(headers.cacheControl
             ? {
-                "cache-control": `max-age=${CACHE_TTL}, public, s-maxage=${SERVER_CACHE_TTL}`,
-                // Add `cdn-cache-control` otherwise Vercel strips `s-maxage` from `cache-control`
-                "cdn-cache-control": `max-age=${SERVER_CACHE_TTL}`,
-              }
-            : undefined),
-        };
+              "cache-control": `max-age=${CACHE_TTL}, public, s-maxage=${SERVER_CACHE_TTL}`,
+            }
+            : undefined)
+        });
+
+        return newHeaders
+
       },
     },
     undici: {

--- a/apps/api/src/app/routes/proxies/coingecko/index.ts
+++ b/apps/api/src/app/routes/proxies/coingecko/index.ts
@@ -40,6 +40,9 @@ const coingeckoProxy: FastifyPluginAsync = async (
 
       },
     },
+    preHandler: async (request) => {
+      fastify.log.info({ url: request.url, method: request.method }, `Request coingecko proxy`);
+    },
     undici: {
       strictContentLength: false, // Prevent errors when content-length header mismatches
     },

--- a/apps/api/src/app/routes/proxies/coingecko/index.ts
+++ b/apps/api/src/app/routes/proxies/coingecko/index.ts
@@ -36,10 +36,6 @@ const coingeckoProxy: FastifyPluginAsync = async (
             : undefined)
         });
 
-        const logOptions = { url: request.url, method: request.method }
-        fastify.log.trace(logOptions, `Old Headers: ${JSON.stringify(headers)}`);
-        fastify.log.trace(logOptions, `New Headers: ${JSON.stringify(newHeaders)}`);
-
         return newHeaders
 
       },

--- a/apps/api/src/app/routes/proxies/coingecko/index.ts
+++ b/apps/api/src/app/routes/proxies/coingecko/index.ts
@@ -36,12 +36,16 @@ const coingeckoProxy: FastifyPluginAsync = async (
             : undefined)
         });
 
+        const logOptions = { url: request.url, method: request.method }
+        fastify.log.trace(logOptions, `Old Headers`);
+        fastify.log.trace(logOptions, `New Headers`);
+
         return newHeaders
 
       },
     },
     preHandler: async (request) => {
-      fastify.log.info({ url: request.url, method: request.method }, `Request coingecko proxy`);
+      fastify.log.debug({ url: request.url, method: request.method }, `Request coingecko proxy`);
     },
     undici: {
       strictContentLength: false, // Prevent errors when content-length header mismatches

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,6 +8,7 @@ const port = process.env.PORT ? Number(process.env.PORT) : 3000;
 const server = Fastify({
   logger: {
     level: process.env.LOG_LEVEL ?? 'info',
+    msgPrefix: '[BFF] '
   },
 });
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -6,7 +6,9 @@ const port = process.env.PORT ? Number(process.env.PORT) : 3000;
 
 // Instantiate Fastify with some config
 const server = Fastify({
-  logger: true,
+  logger: {
+    level: process.env.LOG_LEVEL ?? 'info',
+  },
 });
 
 // Register your application as a normal plugin.

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,7 +8,6 @@ const port = process.env.PORT ? Number(process.env.PORT) : 3000;
 const server = Fastify({
   logger: {
     level: process.env.LOG_LEVEL ?? 'info',
-    msgPrefix: '[BFF] '
   },
 });
 


### PR DESCRIPTION
This PR has a lot of misc changes oriented to test the correct caching of the API.
This PR will improve our debuggability, and will make it easier to test in staging some PR.

I will use it to make sure even if there was not CDN, our AWS won't ask our API twice for a resource that is cacheable. 

## Build on PRs
First of all, we want to test this in our infra (AWS), so it would be easier if we can test already before needing to merge this PR.

For this reason, I made the build of packages be triggered on every commit. This will publish new packages on every change. 

We can use this packages in staging k8s, making it easier to test

You can see now a new tag: `pr-36`: https://github.com/cowprotocol/bff/pkgs/container/bff%2Fapi

<img width="790" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/53bb09ef-2cb6-47fb-b10c-a796ab769b5e">


This allow us to run it even before this PR is merged:

<img width="1053" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/89055b4f-f6c0-4e55-bebd-fcdb71c35dd8">



## Logging support
Adds a new environment variable called `LOG_LEVEL`. This will allow us to control, without redeploying the log level of the app.

## Delete some additional headers
Deletes some additional headers. More specifically, it deletes Cloudflare headers, I don't think we should propagate.

It also changes how I do it. I just thought it was easier to maintain if we keep an array of the ones we want to drop.

