### PR TITLE
Add a simple authentication based on authorized domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,6 @@ PROXY_ORIGIN=proxy-origin
 
 # JWT
 JWT_CERT_PASSPHRASE=secret
+
+# Authorized domains
+AUTHORIZED_ORIGINS=cow.fi

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -16,7 +16,7 @@ const AUTHORIZED_ORIGINS = (() => {
 export const bffAuth: FastifyPluginCallback = (fastify, opts, next) => {
   fastify.addHook('onRequest', async (request, reply) => {
     // Return early if its an unprotected path
-    if (AUTHORIZED_ORIGINS.length == 0 || !PROTECTED_PATHS.some(path => request.url.startsWith(path))) {
+    if (AUTHORIZED_ORIGINS.length === 0 || !PROTECTED_PATHS.some(path => request.url.startsWith(path))) {
       return
     }
 

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -1,0 +1,47 @@
+import fp from "fastify-plugin";
+import { CACHE_CONTROL_HEADER, getCache, getCacheControlHeaderValue, parseCacheControlHeaderValue, setCache } from "../../utils/cache";
+import { FastifyPluginCallback, FastifyReply, FastifyRequest } from "fastify";
+
+const PROTECTED_PATHS = ['/proxies']
+
+const AUTHORIZED_DOMAINS = (() => {
+  const domains = process.env.AUTHORIZED_DOMAINS
+  if (!domains) {
+    return undefined
+  }
+
+  return domains.split(',').map(domain => domain.trim())
+})()
+
+interface BffCacheOptions {
+  ttl?: number
+}
+
+export const bffCache: FastifyPluginCallback<BffCacheOptions> = (fastify, opts, next) => {
+  const { ttl } = opts
+  fastify.addHook('onRequest', async (request, reply) => {
+    // Cache only GET requests
+    if (!AUTHORIZED_DOMAINS) {
+      return
+    }
+
+    // Check the path is withing the protected paths
+    if (!PROTECTED_PATHS.some(path => request.url.startsWith(path))) {
+
+      // Verify the origin is authorized
+      const origin = request.headers.origin
+      if (!origin || !AUTHORIZED_DOMAINS.includes(origin)) {
+        reply.status(403).send('Unauthorized')
+        return
+      }
+    }
+
+    return
+  })
+
+  next()
+}
+
+
+
+export default fp<BffCacheOptions>(bffCache, { fastify: '4.x', name: 'bffAuth' })


### PR DESCRIPTION
Adds a basic auth layer. Is not bullet proof, but it helps to prevent unauthorized access.

It will:
- Protect some specific paths. For now: `['/proxies']`
- It will verify check the origin is what it expects. Should be in the known origins that can be set by `env`: AUTHORIZED_DOMAINS


## Test
### Without env
Request should go through no matter what. No 403 expected. Just test with different origins


### With env
Add to your env:
```
AUTHORIZED_ORIGINS=cow.fi
```


Make sure it works when origin is our localhost:3000 app:
```bash
curl -i 'http://localhost:3010/proxies/tokens' \
  -H 'content-type: application/json' \
  -H 'Origin: http://localhost:3000' \
  --data-raw $'{"query":"\\n  query SearchTokens($searchQuery: String\u0021) {\\n    searchTokens(searchQuery: $searchQuery) {\\n      id\\n      decimals\\n      name\\n      chain\\n      standard\\n      address\\n      symbol\\n      project {\\n        id\\n        logoUrl\\n        safetyLevel\\n        __typename\\n      }\\n      __typename\\n    }\\n  }\\n","variables":{"searchQuery":"anxo"},"operationName":"SearchTokens"}'
```

Works if we change the port
```bash
curl -i 'http://localhost:3010/proxies/tokens' \
  -H 'content-type: application/json' \
  -H 'Origin: http://localhost:4000' \
  --data-raw $'{"query":"\\n  query SearchTokens($searchQuery: String\u0021) {\\n    searchTokens(searchQuery: $searchQuery) {\\n      id\\n      decimals\\n      name\\n      chain\\n      standard\\n      address\\n      symbol\\n      project {\\n        id\\n        logoUrl\\n        safetyLevel\\n        __typename\\n      }\\n      __typename\\n    }\\n  }\\n","variables":{"searchQuery":"anxo"},"operationName":"SearchTokens"}'
```

I didn't add 127.0.0.1 for simplicity, I think is good enough for now, and simpler=better.

Maje sure a random domains fails
```bash
curl -i 'http://localhost:3010/proxies/tokens' \
  -H 'content-type: application/json' \
  -H 'Origin: https://google.com' \
  --data-raw $'{"query":"\\n  query SearchTokens($searchQuery: String\u0021) {\\n    searchTokens(searchQuery: $searchQuery) {\\n      id\\n      decimals\\n      name\\n      chain\\n      standard\\n      address\\n      symbol\\n      project {\\n        id\\n        logoUrl\\n        safetyLevel\\n        __typename\\n      }\\n      __typename\\n    }\\n  }\\n","variables":{"searchQuery":"anxo"},"operationName":"SearchTokens"}'
```

Make sure cow.fi works
```bash
curl -i 'http://localhost:3010/proxies/tokens' \
  -H 'content-type: application/json' \
  -H 'Origin: https://cow.fi' \
  --data-raw $'{"query":"\\n  query SearchTokens($searchQuery: String\u0021) {\\n    searchTokens(searchQuery: $searchQuery) {\\n      id\\n      decimals\\n      name\\n      chain\\n      standard\\n      address\\n      symbol\\n      project {\\n        id\\n        logoUrl\\n        safetyLevel\\n        __typename\\n      }\\n      __typename\\n    }\\n  }\\n","variables":{"searchQuery":"anxo"},"operationName":"SearchTokens"}'
```


CoW Swap and explorer should work too:
```bash
curl -i 'http://localhost:3010/proxies/tokens' \
  -H 'content-type: application/json' \
  -H 'Origin: https://swap.cow.fi' \
  --data-raw $'{"query":"\\n  query SearchTokens($searchQuery: String\u0021) {\\n    searchTokens(searchQuery: $searchQuery) {\\n      id\\n      decimals\\n      name\\n      chain\\n      standard\\n      address\\n      symbol\\n      project {\\n        id\\n        logoUrl\\n        safetyLevel\\n        __typename\\n      }\\n      __typename\\n    }\\n  }\\n","variables":{"searchQuery":"anxo"},"operationName":"SearchTokens"}'

curl -i 'http://localhost:3010/proxies/tokens' \
  -H 'content-type: application/json' \
  -H 'Origin: https://explorer.cow.fi' \
  --data-raw $'{"query":"\\n  query SearchTokens($searchQuery: String\u0021) {\\n    searchTokens(searchQuery: $searchQuery) {\\n      id\\n      decimals\\n      name\\n      chain\\n      standard\\n      address\\n      symbol\\n      project {\\n        id\\n        logoUrl\\n        safetyLevel\\n        __typename\\n      }\\n      __typename\\n    }\\n  }\\n","variables":{"searchQuery":"anxo"},"operationName":"SearchTokens"}'

```


<img width="1074" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/752dba44-2e5a-4a0b-aa8d-cd17dfb6e043">
