### PR TITLE
Don't crash if redis is not up

### DIFF
--- a/apps/api/src/app/connections/redis.ts
+++ b/apps/api/src/app/connections/redis.ts
@@ -1,9 +1,11 @@
 import IORedis from 'ioredis';
 
-export const redis = new IORedis({
+const REDIS_ENABLED = !!process.env.REDIS_HOST
+
+export const redis = REDIS_ENABLED ? new IORedis({
   host: process.env.REDIS_HOST || '127.0.0.1',
   port: parseInt(process.env.REDIS_PORT || '6379', 10),
   db: 0,
   username: process.env.REDIS_USER,
   password: process.env.REDIS_PASSWORD,
-})
+}) : null

--- a/apps/api/src/app/plugins/caching.ts
+++ b/apps/api/src/app/plugins/caching.ts
@@ -5,13 +5,12 @@ import { redis } from '../connections/redis';
 import 'abstract-cache-redis';
 
 
-const isRedisEnabled = !!process.env.REDIS_HOST;
 
 export default fp(async (fastify, opts) => {
   const options: FastifyCachingPluginOptions = {
     ...opts,
 
-    ...(isRedisEnabled ? {
+    ...(redis ? {
       cache: abstractCache({
         useAwait: false,
         driver: {

--- a/apps/api/src/app/plugins/redis.ts
+++ b/apps/api/src/app/plugins/redis.ts
@@ -1,12 +1,15 @@
 import fastifyRedis, { FastifyRedisPluginOptions } from '@fastify/redis';
 
+
 import fp from "fastify-plugin";
 import { redis } from '../connections/redis';
 
 export default fp(async (fastify, opts) => {
-  const options: FastifyRedisPluginOptions = {
-    ...opts,
-    client: redis
-  };
-  fastify.register(fastifyRedis, options);
+  if (redis) {
+    const options: FastifyRedisPluginOptions = {
+      ...opts,
+      client: redis
+    };
+    fastify.register(fastifyRedis, options);
+  }
 });


### PR DESCRIPTION
This PR tries to fix the issue that makes the app crash if REDIS is not setup.

If the envs don't provide the redis host, it will be understood we don't use redis, so it will not using it in the plugins.


