### PR TITLE
Fix overriding cache headers

### DIFF
--- a/apps/api/src/app/routes/proxies/coingecko/index.ts
+++ b/apps/api/src/app/routes/proxies/coingecko/index.ts
@@ -23,13 +23,14 @@ const coingeckoProxy: FastifyPluginAsync = async (
       }),
       // Response headers https://github.com/fastify/fastify-reply-from?tab=readme-ov-file#rewriteheadersheaders-request
       rewriteHeaders: (headers, request) => {
+
         // Drop some headers
         const newHeaders = DROP_HEADERS.reduce((acc, header) => {
           delete acc[header];
           return acc;
         }, {
           ...headers,
-          ...(headers.cacheControl
+          ...(headers[CACHE_CONTROL_HEADER]
             ? {
               [CACHE_CONTROL_HEADER]: getCacheControlHeaderValue(CACHE_TTL),
             }


### PR DESCRIPTION
The cache override had a bug, and was never overriding the cache.

It was always returning 30s cache, which comes from coingecko.

I used now `COINGECKO_CACHING_TIME=3600` and has effect:

<img width="1408" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/0089c6b4-924a-4d2c-9596-4c5d8a874cae">
