### PR TITLE
Use logger for the API project

### DIFF
--- a/apps/api/src/app/plugins/bffCache.ts
+++ b/apps/api/src/app/plugins/bffCache.ts
@@ -55,7 +55,6 @@ export const bffCache: FastifyPluginCallback<BffCacheOptions> = (fastify, opts, 
 
     let key = getKey(req)
     setCache(key, payload, cacheTtl, fastify).catch(e => {
-      console.error('Error getting key', key, e)
       fastify.log.error(`Error setting key ${key} from cache`, e)
       return null
     })

--- a/apps/api/src/app/routes/about.ts
+++ b/apps/api/src/app/routes/about.ts
@@ -6,6 +6,7 @@ const GIT_COMMIT_HASH_FILE = 'git-commit-hash.txt';
 const VERSION = process.env.VERSION || 'UNKNOWN, please set the environment variable';
 const COMMIT_HASH = getCommitHash();
 import { join } from 'path';
+import { server } from '../../main';
 
 
 
@@ -34,7 +35,7 @@ function getCommitHash(): string | undefined {
     return readFileSync(filePath, 'utf-8')
   } catch (error) {
     // Not a big deal, if the file is not present, the about won't 
-    console.warn(`Unable to read the file with the git commit hash: ${filePath}. /about endpoint won't export the 'gitCommitHash'`);
+    server.log.warn(`Unable to read the file with the git commit hash: ${filePath}. /about endpoint won't export the 'gitCommitHash'`);
     return undefined
   }
 }

--- a/apps/api/src/app/routes/examples/hello.ts
+++ b/apps/api/src/app/routes/examples/hello.ts
@@ -10,7 +10,6 @@ const root: FastifyPluginAsync = async (fastify): Promise<void> => {
 
   fastify.get('/hello-cached', async function (request, reply) {
     await delay(2000)
-    console.log('Setting cache header')
     reply.header(CACHE_CONTROL_HEADER, getCacheControlHeaderValue(10))
     reply.send({ hello: 'world' })
   });

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,7 +5,7 @@ const host = process.env.HOST ?? 'localhost';
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
 
 // Instantiate Fastify with some config
-const server = Fastify({
+export const server = Fastify({
   logger: {
     level: process.env.LOG_LEVEL ?? 'info',
   },
@@ -20,6 +20,6 @@ server.listen({ port, host }, (err) => {
     server.log.error(err);
     process.exit(1);
   } else {
-    console.log(`[ ready ] http://${host}:${port}`);
+    server.log.info(`[ ready ] http://${host}:${port}`);
   }
 });


### PR DESCRIPTION
Make use of the logger in the API project. 

Its best to not use directly the console log, because we expect some specific format in the logs we parse (we use pino logger)

This PR removes some console.logs and replaces by the logger 