### PR TITLE
Expose default slippage

### DIFF
--- a/apps/api/src/app/app.ts
+++ b/apps/api/src/app/app.ts
@@ -33,6 +33,7 @@ const app: FastifyPluginAsync<AppOptions> = async (
   void fastify.register(AutoLoad, {
     dir: join(__dirname, 'routes'),
     options: appOpts,
+    routeParams: true
   });
 };
 

--- a/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
+++ b/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
@@ -1,0 +1,48 @@
+import { ChainIdSchema, ETHEREUM_ADDRESS_PATTERN } from '../../../../../schemas';
+import { FastifyPluginAsync } from 'fastify';
+import { FromSchema, JSONSchema } from 'json-schema-to-ts';
+
+interface Result {
+  slippagePercent: number;
+}
+
+const routeSchema = {
+  type: 'object',
+  required: ['chainId', 'sellToken', 'buyToken'],
+  properties: {
+    chainId: ChainIdSchema,
+    sellToken: {
+      title: 'Sell token address',
+      description: 'Sell token address',
+      type: "string",
+      pattern: ETHEREUM_ADDRESS_PATTERN
+    },
+    buyToken: {
+      title: 'Buy token address',
+      description: 'Buy token address',
+      type: 'string',
+      pattern: ETHEREUM_ADDRESS_PATTERN
+    },
+  },
+} as const satisfies JSONSchema;
+
+
+type RouteSchema = FromSchema<typeof routeSchema>;
+
+
+const root: FastifyPluginAsync = async (fastify): Promise<void> => {
+  // example: http://localhost:3010/chains/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/defaultSlippageTolerance
+
+  fastify.get<{
+    Params: RouteSchema;
+    Reply: Result;
+  }>('/defaultSlippageTolerance', {
+    schema: { params: routeSchema }
+  }, async function (request, reply) {
+    const { chainId, sellTokenAddress, buyTokenAddress } = request.params;
+    fastify.log.info(`Get default slippage for market ${sellTokenAddress}-${buyTokenAddress} on chain ${chainId}`);
+    reply.send({ slippagePercent: 0.5 })
+  });
+};
+
+export default root;

--- a/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
+++ b/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
@@ -32,7 +32,6 @@ type RouteSchema = FromSchema<typeof routeSchema>;
 
 const root: FastifyPluginAsync = async (fastify): Promise<void> => {
   // example: http://localhost:3010/chains/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/defaultSlippageTolerance
-
   fastify.get<{
     Params: RouteSchema;
     Reply: Result;

--- a/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
+++ b/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
@@ -3,7 +3,7 @@ import { FastifyPluginAsync } from 'fastify';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 
 interface Result {
-  slippagePercent: number;
+  slippageBps: number;
 }
 
 const routeSchema = {
@@ -40,7 +40,7 @@ const root: FastifyPluginAsync = async (fastify): Promise<void> => {
   }, async function (request, reply) {
     const { chainId, sellTokenAddress, buyTokenAddress } = request.params;
     fastify.log.info(`Get default slippage for market ${sellTokenAddress}-${buyTokenAddress} on chain ${chainId}`);
-    reply.send({ slippagePercent: 0.5 })
+    reply.send({ slippageBps: 50 })
   });
 };
 

--- a/apps/api/src/app/schemas.ts
+++ b/apps/api/src/app/schemas.ts
@@ -1,0 +1,9 @@
+
+export const ChainIdSchema = {
+  title: 'Chain ID',
+  description: 'Chain ID',
+  enum: [1, 100, 42161, 11155111],
+  type: 'integer',
+} as const
+
+export const ETHEREUM_ADDRESS_PATTERN = "^0x[a-fA-F0-9]{40}$"


### PR DESCRIPTION
This PR makes a mock endpoint we can use to get the default slippage

<img width="1470" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/2edd763d-b40f-40ff-b326-2cb56143dd60">


This way, we can implement on a later PR our heuristic (using coingecko API, orderbook API, CMS, or whatever we see suitable)

## Validation
The endpoint will validate the chain is an integer:
<img width="672" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/8539b9cc-5b8a-4336-a8c5-7175327598c3">


Also that is supported chain:

<img width="1045" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/d6b545b2-0a3c-4045-aa6f-117f15776d14">

Same for the market, it will require they are Ethereum addresses.


## Next steps
This is a mock value that returns our current default, we can discuss the heuristic now and iterate on this. 



## Test
https://bff.barn.cow.fi/chains/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/defaultSlippageTolerance