### PR TITLE
feat: improve swagger docs for the slippage endpoint

### DIFF
--- a/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
+++ b/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
@@ -1,4 +1,7 @@
-import { ChainIdSchema, ETHEREUM_ADDRESS_PATTERN } from '../../../../../schemas';
+import {
+  ChainIdSchema,
+  ETHEREUM_ADDRESS_PATTERN,
+} from '../../../../../schemas';
 import { FastifyPluginAsync } from 'fastify';
 import { FromSchema, JSONSchema } from 'json-schema-to-ts';
 
@@ -14,34 +17,38 @@ const routeSchema = {
     sellToken: {
       title: 'Sell token address',
       description: 'Sell token address',
-      type: "string",
-      pattern: ETHEREUM_ADDRESS_PATTERN
+      type: 'string',
+      pattern: ETHEREUM_ADDRESS_PATTERN,
     },
     buyToken: {
       title: 'Buy token address',
       description: 'Buy token address',
       type: 'string',
-      pattern: ETHEREUM_ADDRESS_PATTERN
+      pattern: ETHEREUM_ADDRESS_PATTERN,
     },
   },
 } as const satisfies JSONSchema;
 
-
 type RouteSchema = FromSchema<typeof routeSchema>;
-
 
 const root: FastifyPluginAsync = async (fastify): Promise<void> => {
   // example: http://localhost:3010/chains/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/defaultSlippageTolerance
   fastify.get<{
     Params: RouteSchema;
     Reply: Result;
-  }>('/defaultSlippageTolerance', {
-    schema: { params: routeSchema }
-  }, async function (request, reply) {
-    const { chainId, sellTokenAddress, buyTokenAddress } = request.params;
-    fastify.log.info(`Get default slippage for market ${sellTokenAddress}-${buyTokenAddress} on chain ${chainId}`);
-    reply.send({ slippageBps: 50 })
-  });
+  }>(
+    '/defaultSlippageTolerance',
+    {
+      schema: { params: routeSchema },
+    },
+    async function (request, reply) {
+      const { chainId, sellTokenAddress, buyTokenAddress } = request.params;
+      fastify.log.info(
+        `Get default slippage for market ${sellTokenAddress}-${buyTokenAddress} on chain ${chainId}`
+      );
+      reply.send({ slippageBps: 50 });
+    }
+  );
 };
 
 export default root;

--- a/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
+++ b/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
@@ -36,6 +36,7 @@ const root: FastifyPluginAsync = async (fastify): Promise<void> => {
   fastify.get<{
     Params: RouteSchema;
     Reply: Result;
+<<<<<<< HEAD
   }>(
     '/defaultSlippageTolerance',
     {
@@ -49,6 +50,15 @@ const root: FastifyPluginAsync = async (fastify): Promise<void> => {
       reply.send({ slippageBps: 50 });
     }
   );
+=======
+  }>('/defaultSlippageTolerance', {
+    schema: { params: routeSchema }
+  }, async function (request, reply) {
+    const { chainId, sellTokenAddress, buyTokenAddress } = request.params;
+    fastify.log.info(`Get default slippage for market ${sellTokenAddress}-${buyTokenAddress} on chain ${chainId}`);
+    reply.send({ slippageBps: 50 })
+  });
+>>>>>>> ec8f7c4 (Use BPS)
 };
 
 export default root;

--- a/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
+++ b/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/defaultSlippageTolerance.ts
@@ -14,17 +14,33 @@ const routeSchema = {
   required: ['chainId', 'sellToken', 'buyToken'],
   properties: {
     chainId: ChainIdSchema,
-    sellToken: {
-      title: 'Sell token address',
-      description: 'Sell token address',
+    baseTokenAddress: {
+      title: 'Base token address',
+      description: 'Currency that is being bought or sold.',
       type: 'string',
       pattern: ETHEREUM_ADDRESS_PATTERN,
     },
-    buyToken: {
-      title: 'Buy token address',
-      description: 'Buy token address',
+    quoteTokenAddress: {
+      title: 'Quote token address',
+      description: ' Currency in which the price of the base token is quoted.',
       type: 'string',
       pattern: ETHEREUM_ADDRESS_PATTERN,
+    },
+  },
+} as const satisfies JSONSchema;
+
+const responseSchema = {
+  type: 'object',
+  required: ['slippageBps'],
+  properties: {
+    slippageBps: {
+      title: 'Slippage tolerance in basis points',
+      description:
+        'Slippage tolerance in basis points. One basis point is equivalent to 0.01% (1/100th of a percent)',
+      type: 'number',
+      examples: [50, 100, 200],
+      minimum: 0,
+      maximum: 10000,
     },
   },
 } as const satisfies JSONSchema;
@@ -36,29 +52,24 @@ const root: FastifyPluginAsync = async (fastify): Promise<void> => {
   fastify.get<{
     Params: RouteSchema;
     Reply: Result;
-<<<<<<< HEAD
   }>(
     '/defaultSlippageTolerance',
     {
-      schema: { params: routeSchema },
+      schema: {
+        params: routeSchema,
+        response: {
+          '2XX': responseSchema,
+        },
+      },
     },
     async function (request, reply) {
-      const { chainId, sellTokenAddress, buyTokenAddress } = request.params;
+      const { chainId, baseTokenAddress, quoteTokenAddress } = request.params;
       fastify.log.info(
-        `Get default slippage for market ${sellTokenAddress}-${buyTokenAddress} on chain ${chainId}`
+        `Get default slippage for market ${baseTokenAddress}-${quoteTokenAddress} on chain ${chainId}`
       );
       reply.send({ slippageBps: 50 });
     }
   );
-=======
-  }>('/defaultSlippageTolerance', {
-    schema: { params: routeSchema }
-  }, async function (request, reply) {
-    const { chainId, sellTokenAddress, buyTokenAddress } = request.params;
-    fastify.log.info(`Get default slippage for market ${sellTokenAddress}-${buyTokenAddress} on chain ${chainId}`);
-    reply.send({ slippageBps: 50 })
-  });
->>>>>>> ec8f7c4 (Use BPS)
 };
 
 export default root;

--- a/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/slippageTolerance.ts
+++ b/apps/api/src/app/routes/chains/__chainId/markets/__sellToken-__buyToken/slippageTolerance.ts
@@ -11,7 +11,7 @@ interface Result {
 
 const routeSchema = {
   type: 'object',
-  required: ['chainId', 'sellToken', 'buyToken'],
+  required: ['chainId', 'baseTokenAddress', 'quoteTokenAddress'],
   properties: {
     chainId: ChainIdSchema,
     baseTokenAddress: {
@@ -48,12 +48,12 @@ const responseSchema = {
 type RouteSchema = FromSchema<typeof routeSchema>;
 
 const root: FastifyPluginAsync = async (fastify): Promise<void> => {
-  // example: http://localhost:3010/chains/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/defaultSlippageTolerance
+  // example: http://localhost:3010/chains/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/slippageTolerance
   fastify.get<{
     Params: RouteSchema;
     Reply: Result;
   }>(
-    '/defaultSlippageTolerance',
+    '/slippageTolerance',
     {
       schema: {
         params: routeSchema,


### PR DESCRIPTION
Small iteration on #45 to improve the swagger docs.

I changed my mind also regarding the parameters. I like more the base/quote notation for modeling markets

<img width="1496" alt="image" src="https://github.com/cowprotocol/bff/assets/2352112/86012095-639a-43ab-92e5-282c87e6ed2c">
