### PR TITLE
Add slippage service - suggest 3 layered architecture

### DIFF
--- a/libs/repositories/.eslintrc.json
+++ b/libs/repositories/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/repositories/README.md
+++ b/libs/repositories/README.md
@@ -1,0 +1,7 @@
+# repositories
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test repositories` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/repositories/jest.config.ts
+++ b/libs/repositories/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'repositories',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/libs/repositories',
+};

--- a/libs/repositories/project.json
+++ b/libs/repositories/project.json
@@ -1,0 +1,30 @@
+{
+  "name": "repositories",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/repositories/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/repositories/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/repositories/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/repositories/src/UsdRepository.ts
+++ b/libs/repositories/src/UsdRepository.ts
@@ -1,0 +1,16 @@
+import { get } from 'http';
+
+export interface UsdRepository {
+  getDailyUsdPrice(tokenAddress: string, date: Date): Promise<number>;
+}
+
+export class UsdRepositoryMock implements UsdRepository {
+  async getDailyUsdPrice(tokenAddress: string, date: Date): Promise<number> {
+    return 1234;
+  }
+}
+
+// TODO: Remove once we have IoC
+export function getUsdRepository(): UsdRepository {
+  return new UsdRepositoryMock();
+}

--- a/libs/repositories/tsconfig.json
+++ b/libs/repositories/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/repositories/tsconfig.lib.json
+++ b/libs/repositories/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/repositories/tsconfig.spec.json
+++ b/libs/repositories/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/services/.eslintrc.json
+++ b/libs/services/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/services/README.md
+++ b/libs/services/README.md
@@ -1,0 +1,7 @@
+# services
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test services` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/services/jest.config.ts
+++ b/libs/services/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'services',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/libs/services',
+};

--- a/libs/services/project.json
+++ b/libs/services/project.json
@@ -1,0 +1,30 @@
+{
+  "name": "services",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/services/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/services/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/services/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/services/src/SlippageService/SlippageService.spec.ts
+++ b/libs/services/src/SlippageService/SlippageService.spec.ts
@@ -1,0 +1,9 @@
+import { getSlippageService } from './SlippageService';
+
+const slippageService = getSlippageService();
+
+describe('SlippageService', () => {
+  it('should return always 50', () => {
+    expect(slippageService.getSlippageBps('0x0', '0x0')).toEqual(50);
+  });
+});

--- a/libs/services/src/SlippageService/SlippageService.ts
+++ b/libs/services/src/SlippageService/SlippageService.ts
@@ -1,0 +1,20 @@
+/**
+ * BPS (Basis Points)
+ */
+export type Bps = number;
+
+export interface SlippageService {
+  getSlippageBps(quoteTokenAddress: string, baseTokenAddress: string): Bps;
+}
+
+// TODO: Find good name for the implementation, as Leandro don't like "Impl" suffix, just don't want to couple it to add Coingecko in its name (as that would couple it to the data-source, and the adding a name to specify the algorithm might complicate the name, as this will use some custom logic based on standard deviation, so for now as we plan to have just one implementation, I want to keep it simple. But happy to get ideas here)
+export class SlippageServiceImpl implements SlippageService {
+  getSlippageBps(_quoteTokenAddress: string, _baseTokenAddress: string): Bps {
+    return 50;
+  }
+}
+
+// TODO: This is just temporal! I will introduce a IoC framework in a follow up
+export function getSlippageService(): SlippageService {
+  return new SlippageServiceImpl();
+}

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -1,0 +1,1 @@
+export * from './SlippageService/SlippageService';

--- a/libs/services/tsconfig.json
+++ b/libs/services/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/services/tsconfig.lib.json
+++ b/libs/services/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/services/tsconfig.spec.json
+++ b/libs/services/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
       "@cowprotocol/abis": ["libs/abis/src/index.ts"],
       "@cowprotocol/cms-api": ["libs/cms-api/src/index.ts"],
       "@cowprotocol/notifications": ["libs/notifications/src/index.ts"],
+      "@cowprotocol/repositories": ["libs/repositories/src/index.ts"],
       "@cowprotocol/services": ["libs/services/src/index.ts"]
     }
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,10 +10,7 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": [
-      "es2020",
-      "dom"
-    ],
+    "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
@@ -21,19 +18,11 @@
     "esModuleInterop": true,
     "allowJs": true,
     "paths": {
-      "@cowprotocol/abis": [
-        "libs/abis/src/index.ts"
-      ],
-      "@cowprotocol/cms-api": [
-        "libs/cms-api/src/index.ts"
-      ],
-      "@cowprotocol/notifications": [
-        "libs/notifications/src/index.ts"
-      ]
+      "@cowprotocol/abis": ["libs/abis/src/index.ts"],
+      "@cowprotocol/cms-api": ["libs/cms-api/src/index.ts"],
+      "@cowprotocol/notifications": ["libs/notifications/src/index.ts"],
+      "@cowprotocol/services": ["libs/services/src/index.ts"]
     }
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6602,7 +6602,7 @@ node-fetch@^2.6.12:
 
 node-fetch@^3.3.2:
   version "3.3.2"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
   integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
   dependencies:
     data-uri-to-buffer "^4.0.0"


### PR DESCRIPTION
This PR is the first of a series I'd like to add to BFF.

## Context on why a service library
We will have a growing complexity in BFF and I thought about making a suggestion.

My general plan is to:
- Create 2 new libraries `services` (in this PR) and `repositories` (follow up)
- Our API will just delegate all work to a service, this way, the API layer remains lightweight and all business logic is moved to the service.
- The service might make use of one or more repositories to access the information 
- The repositories allows us to abstract how we access the data (separation on data access from the service logic)
- I would also like to work with Typescript interfaces for these 2 layers (to hide implementation details), and potentially have more than one implementation. This will help with unit testing for example, or implement a cached version of a repository.
- Finally, I would like to introduce a IoC framework (to decouple everything)

I will do the PoC just to implement some basic slippage service

## What if we need to create too many services or repositories?
For now, one library for all services and one library for all repositories suffice in my opinion. If at some point in the future, it becomes too big, we can always split it into multiple service libraries (for example, by domain).

## This PR
- [x] Adds just the service layer (lib)
- [x] Adds the slippage service 
   - [x] interface
   - [x] the implementation
   - [x] factory method which will be removed once the IoC is added


## Test 

`nx run services:test --watch`

<img width="816" alt="Screenshot at Jul 08 20-55-00" src="https://github.com/cowprotocol/bff/assets/2352112/6db56123-bf5e-44b9-8a62-8a9cd1eda1ce">

