### PR TITLE
Implement and expose USD service

### DIFF
--- a/apps/api/src/app/inversify.config.ts
+++ b/apps/api/src/app/inversify.config.ts
@@ -3,11 +3,15 @@ import {
   UsdRepositoryCoingecko,
   usdRepositorySymbol,
 } from '@cowprotocol/repositories';
+
 import { Container } from 'inversify';
 import {
   SlippageService,
-  SlippageServiceImpl,
+  SlippageServiceMain,
+  UsdService,
+  UsdServiceMain,
   slippageServiceSymbol,
+  usdServiceSymbol,
 } from '@cowprotocol/services';
 
 export const apiContainer = new Container();
@@ -20,4 +24,6 @@ apiContainer
 // Services
 apiContainer
   .bind<SlippageService>(slippageServiceSymbol)
-  .to(SlippageServiceImpl);
+  .to(SlippageServiceMain);
+
+apiContainer.bind<UsdService>(usdServiceSymbol).to(UsdServiceMain);

--- a/apps/api/src/app/routes/chains/__chainId/markets/__baseTokenAddress-__quoteTokenAddress/slippageTolerance.ts
+++ b/apps/api/src/app/routes/chains/__chainId/markets/__baseTokenAddress-__quoteTokenAddress/slippageTolerance.ts
@@ -11,16 +11,15 @@ import {
   getCacheControlHeaderValue,
 } from '../../../../../../utils/cache';
 
+const CACHE_SECONDS = 120;
+
 // TODO:  Add this in a follow up PR
 // import { ALL_SUPPORTED_CHAIN_IDS } from '@cowprotocol/cow-sdk';
-
-interface Result {
-  slippageBps: number;
-}
 
 const routeSchema = {
   type: 'object',
   required: ['chainId', 'baseTokenAddress', 'quoteTokenAddress'],
+  additionalProperties: false,
   properties: {
     chainId: ChainIdSchema,
     baseTokenAddress: {
@@ -38,16 +37,17 @@ const routeSchema = {
   },
 } as const satisfies JSONSchema;
 
-const responseSchema = {
+const successSchema = {
   type: 'object',
   required: ['slippageBps'],
+  additionalProperties: false,
   properties: {
     slippageBps: {
       title: 'Slippage tolerance in basis points',
       description:
         'Slippage tolerance in basis points. One basis point is equivalent to 0.01% (1/100th of a percent)',
       type: 'number',
-      examples: [50, 100, 200], // [ALL_SUPPORTED_CHAIN_IDS],
+      examples: [50, 100, 200],
       minimum: 0,
       maximum: 10000,
     },
@@ -55,6 +55,7 @@ const responseSchema = {
 } as const satisfies JSONSchema;
 
 type RouteSchema = FromSchema<typeof routeSchema>;
+type SuccessSchema = FromSchema<typeof successSchema>;
 
 const slippageService: SlippageService = apiContainer.get(
   slippageServiceSymbol
@@ -64,14 +65,14 @@ const root: FastifyPluginAsync = async (fastify): Promise<void> => {
   // example: http://localhost:3010/chains/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/slippageTolerance
   fastify.get<{
     Params: RouteSchema;
-    Reply: Result;
+    Reply: SuccessSchema;
   }>(
     '/slippageTolerance',
     {
       schema: {
         params: routeSchema,
         response: {
-          '2XX': responseSchema,
+          '2XX': successSchema,
         },
       },
     },
@@ -84,7 +85,10 @@ const root: FastifyPluginAsync = async (fastify): Promise<void> => {
         baseTokenAddress,
         quoteTokenAddress
       );
-      reply.header(CACHE_CONTROL_HEADER, getCacheControlHeaderValue(120));
+      reply.header(
+        CACHE_CONTROL_HEADER,
+        getCacheControlHeaderValue(CACHE_SECONDS)
+      );
       reply.send({ slippageBps });
     }
   );

--- a/apps/api/src/app/routes/chains/__chainId/tokens/__tokenAddress/usdPrice.ts
+++ b/apps/api/src/app/routes/chains/__chainId/tokens/__tokenAddress/usdPrice.ts
@@ -1,0 +1,99 @@
+import { UsdService, usdServiceSymbol } from '@cowprotocol/services';
+import {
+  ChainIdSchema,
+  ETHEREUM_ADDRESS_PATTERN,
+} from '../../../../../schemas';
+import { FastifyPluginAsync } from 'fastify';
+import { FromSchema, JSONSchema } from 'json-schema-to-ts';
+import { apiContainer } from '../../../../../inversify.config';
+
+// TODO:  Add this in a follow up PR
+// import { ALL_SUPPORTED_CHAIN_IDS } from '@cowprotocol/cow-sdk';
+
+interface Result {
+  price: number;
+}
+
+const paramsSchema = {
+  type: 'object',
+  required: ['chainId', 'tokenAddress'],
+  additionalProperties: false,
+  properties: {
+    chainId: ChainIdSchema,
+    tokenAddress: {
+      title: 'Token address',
+      description: 'Token address.',
+      type: 'string',
+      pattern: ETHEREUM_ADDRESS_PATTERN,
+    },
+  },
+} as const satisfies JSONSchema;
+
+const successSchema = {
+  type: 'object',
+  required: ['price'],
+  additionalProperties: false,
+  properties: {
+    price: {
+      title: 'Price',
+      description: 'Current price of the token in USD.',
+      type: 'number',
+      examples: [3561.1267842],
+    },
+  },
+} as const satisfies JSONSchema;
+
+const errorSchema = {
+  type: 'object',
+  required: ['message'],
+  additionalProperties: false,
+  properties: {
+    message: {
+      title: 'Message',
+      description: 'Message describing the error.',
+      type: 'string',
+      examples: ['Price not found'],
+    },
+  },
+} as const satisfies JSONSchema;
+
+type RouteSchema = FromSchema<typeof paramsSchema>;
+type SuccessSchema = FromSchema<typeof successSchema>;
+type ErrorSchema = FromSchema<typeof errorSchema>;
+
+const usdService: UsdService = apiContainer.get(usdServiceSymbol);
+
+const root: FastifyPluginAsync = async (fastify): Promise<void> => {
+  // example: http://localhost:3010/chains/1/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/usdPrice
+  fastify.get<{
+    Params: RouteSchema;
+    Reply: SuccessSchema | ErrorSchema;
+  }>(
+    '/usdPrice',
+    {
+      schema: {
+        params: paramsSchema,
+        response: {
+          '2XX': successSchema,
+          '404': errorSchema,
+        },
+      },
+    },
+    async function (request, reply) {
+      const { chainId, tokenAddress } = request.params;
+
+      const price = await usdService.getUsdPrice(chainId, tokenAddress);
+      fastify.log.info(
+        `Get USD value for ${tokenAddress} on chain ${chainId}: ${price}`
+      );
+      if (!price) {
+        reply.code(404).send({ message: 'Price not found' });
+        return;
+      }
+
+      reply.send({ price });
+    }
+  );
+};
+
+export default root;

--- a/libs/repositories/src/UsdRepository/UsdRepositoryRedis.ts
+++ b/libs/repositories/src/UsdRepository/UsdRepositoryRedis.ts
@@ -10,8 +10,8 @@ import { SupportedChainId } from '../types';
 import IORedis from 'ioredis';
 import ms from 'ms';
 
-const DEFAULT_CACHE_VALUE_SECONDS = ms('2min'); // 2min cache time by default for values
-const DEFAULT_CACHE_NULL_SECONDS = ms('30min'); // 2min cache time by default for NULL values (when the repository don't know)
+const DEFAULT_CACHE_VALUE_SECONDS = ms('2min') / 1000; // 2min cache time by default for values
+const DEFAULT_CACHE_NULL_SECONDS = ms('30min') / 1000; // 2min cache time by default for NULL values (when the repository don't know)
 const NULL_VALUE = 'null';
 
 @injectable()

--- a/libs/services/src/SlippageService/SlippageService.ts
+++ b/libs/services/src/SlippageService/SlippageService.ts
@@ -22,7 +22,7 @@ export interface SlippageService {
 export const slippageServiceSymbol = Symbol.for('SlippageService');
 
 @injectable()
-export class SlippageServiceImpl implements SlippageService {
+export class SlippageServiceMain implements SlippageService {
   constructor(
     @inject(usdRepositorySymbol)
     private usdRepository: UsdRepository

--- a/libs/services/src/UsdService/UsdService.ts
+++ b/libs/services/src/UsdService/UsdService.ts
@@ -1,0 +1,30 @@
+import {
+  UsdRepository,
+  usdRepositorySymbol,
+  SupportedChainId,
+} from '@cowprotocol/repositories';
+import { injectable, inject } from 'inversify';
+
+export interface UsdService {
+  getUsdPrice(
+    chainId: SupportedChainId,
+    tokenAddress: string
+  ): Promise<number | null>;
+}
+
+export const usdServiceSymbol = Symbol.for('UsdService');
+
+@injectable()
+export class UsdServiceMain implements UsdService {
+  constructor(
+    @inject(usdRepositorySymbol)
+    private usdRepository: UsdRepository
+  ) {}
+
+  async getUsdPrice(
+    chainId: SupportedChainId,
+    tokenAddress: string
+  ): Promise<number | null> {
+    return this.usdRepository.getUsdPrice(chainId, tokenAddress);
+  }
+}

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -1,1 +1,2 @@
 export * from './SlippageService/SlippageService';
+export * from './UsdService/UsdService';


### PR DESCRIPTION
## Implement USD Service
This PR implements a very basic UsdService, which just delegates to the repository. Because the service logic is dumb I didn't do any unit tests (it feels overkill, the relevant tests for USD are in the repositories)

The repository is injected, so the service doesn't care about the specific implementation.

<img width="983" alt="Screenshot at Jul 18 22-40-38" src="https://github.com/user-attachments/assets/77e43696-ef02-4565-9aa1-cfb57af49708">


<img width="1062" alt="Screenshot at Jul 18 22-41-47" src="https://github.com/user-attachments/assets/32517b98-d95a-4d8b-a847-39893d01b7d9">


## Expose USD API
Exposes the service through a basic API

`/chains/1/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/usdPrice` 

#alfetopito I know you don't like. I'm happy to do a refactor to `/1/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/usdPrice` but we will need to then make it backward compatible with the slippage endpoint. I added chains to be more explicit (I think is not the purest API definition, if the ID there doesn't have context), but we can compromise that for simplicity's sake. I'm mostly indifferent (slightly favour explicit, but I don't care a lot)

## Test

Run locally for a few tokens. In this PR you will notice some small delay (because there's no caching, and checks in Coingecko all the time). There's no fallback logics and native_price in COW is not used. All that, coming in follow up PRs :) 

Check different tokens in:
http://localhost:3010/chains/1/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/usdPrice




