### PR TITLE
Create usd repo using composition of other repos + In-memory caching

### DIFF
--- a/apps/api/src/app/inversify.config.ts
+++ b/apps/api/src/app/inversify.config.ts
@@ -29,7 +29,7 @@ function getUsdRepositoryCow(): UsdRepository {
     return usdRepositoryCow;
   }
 
-  return new UsdRepositoryRedis(usdRepositoryCow, redisClient, 'usd');
+  return new UsdRepositoryRedis(usdRepositoryCow, redisClient, 'usdCow');
 }
 
 function getUsdRepositoryCoingecko(): UsdRepository {
@@ -39,7 +39,11 @@ function getUsdRepositoryCoingecko(): UsdRepository {
     return usdRepositoryCoingecko;
   }
 
-  return new UsdRepositoryRedis(usdRepositoryCoingecko, redisClient, 'usd');
+  return new UsdRepositoryRedis(
+    usdRepositoryCoingecko,
+    redisClient,
+    'usdCoingecko'
+  );
 }
 
 function getUsdRepository(): UsdRepository {

--- a/apps/api/src/app/routes/__chainId/tokens/__tokenAddress/usdPrice.ts
+++ b/apps/api/src/app/routes/__chainId/tokens/__tokenAddress/usdPrice.ts
@@ -83,7 +83,7 @@ const root: FastifyPluginAsync = async (fastify): Promise<void> => {
       fastify.log.info(
         `Get USD value for ${tokenAddress} on chain ${chainId}: ${price}`
       );
-      if (!price) {
+      if (price === null) {
         reply.code(404).send({ message: 'Price not found' });
         return;
       }

--- a/libs/repositories/src/CacheRepository/CacheRepository.ts
+++ b/libs/repositories/src/CacheRepository/CacheRepository.ts
@@ -1,0 +1,4 @@
+export interface CacheRepository {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttl: number): Promise<void>;
+}

--- a/libs/repositories/src/CacheRepository/CacheRepository.ts
+++ b/libs/repositories/src/CacheRepository/CacheRepository.ts
@@ -1,3 +1,5 @@
+export const cacheRepositorySymbol = Symbol.for('CacheRepository');
+
 export interface CacheRepository {
   get(key: string): Promise<string | null>;
   set(key: string, value: string, ttl: number): Promise<void>;

--- a/libs/repositories/src/CacheRepository/CacheRepositoryMemory.ts
+++ b/libs/repositories/src/CacheRepository/CacheRepositoryMemory.ts
@@ -9,7 +9,7 @@ export class CacheRepositoryMemory implements CacheRepository {
   async get(key: string): Promise<string | null> {
     const value = await CacheRepositoryMemory.cache.get<string>(key);
 
-    return value || null;
+    return value ?? null;
   }
 
   async set(key: string, value: string, ttl: number): Promise<void> {

--- a/libs/repositories/src/CacheRepository/CacheRepositoryMemory.ts
+++ b/libs/repositories/src/CacheRepository/CacheRepositoryMemory.ts
@@ -1,0 +1,18 @@
+import { injectable } from 'inversify';
+import NodeCache from 'node-cache';
+import { CacheRepository } from './CacheRepository';
+
+@injectable()
+export class CacheRepositoryMemory implements CacheRepository {
+  static cache: NodeCache = new NodeCache();
+
+  async get(key: string): Promise<string | null> {
+    const value = await CacheRepositoryMemory.cache.get<string>(key);
+
+    return value || null;
+  }
+
+  async set(key: string, value: string, ttl: number): Promise<void> {
+    await CacheRepositoryMemory.cache.set(key, value, ttl);
+  }
+}

--- a/libs/repositories/src/CacheRepository/CacheRepositoryRedis.ts
+++ b/libs/repositories/src/CacheRepository/CacheRepositoryRedis.ts
@@ -1,0 +1,15 @@
+import { injectable } from 'inversify';
+import { CacheRepository } from './CacheRepository';
+
+@injectable()
+export class CacheRepositoryRedis implements CacheRepository {
+  constructor(private redisClient: any) {}
+
+  async get(key: string): Promise<string | null> {
+    return this.redisClient.get(key);
+  }
+
+  async set(key: string, value: string, ttl: number): Promise<void> {
+    await this.redisClient.set(key, value, 'EX', ttl);
+  }
+}

--- a/libs/repositories/src/UsdRepository/UsdRepositoryCache.spec.ts
+++ b/libs/repositories/src/UsdRepository/UsdRepositoryCache.spec.ts
@@ -1,6 +1,7 @@
-import { UsdRepositoryRedis } from './UsdRepositoryRedis';
+import { UsdRepositoryCache } from './UsdRepositoryCache';
 import IORedis from 'ioredis';
 import { UsdRepository } from './UsdRepository';
+import { CacheRepositoryRedis } from '../CacheRepository/CacheRepositoryRedis';
 import { SupportedChainId } from '../types';
 import { WETH } from '../../test/mock';
 import type { PricePoint } from './UsdRepository';
@@ -15,8 +16,8 @@ jest.mock('ioredis', () => {
   }));
 });
 
-describe('UsdRepositoryRedis', () => {
-  let usdRepositoryRedis: UsdRepositoryRedis;
+describe('UsdRepositoryCache', () => {
+  let usdRepositoryCache: UsdRepositoryCache;
   let redisMock: jest.Mocked<IORedis>;
   let proxyMock: jest.Mocked<UsdRepository>;
 
@@ -26,9 +27,10 @@ describe('UsdRepositoryRedis', () => {
       getUsdPrice: jest.fn(),
       getUsdPrices: jest.fn(),
     };
-    usdRepositoryRedis = new UsdRepositoryRedis(
+    const cacheRepository = new CacheRepositoryRedis(redisMock);
+    usdRepositoryCache = new UsdRepositoryCache(
       proxyMock,
-      redisMock,
+      cacheRepository,
       'testCache',
       CACHE_VALUE_SECONDS,
       CACHE_NULL_SECONDS
@@ -44,7 +46,7 @@ describe('UsdRepositoryRedis', () => {
       proxyMock.getUsdPrice.mockResolvedValue(200);
 
       // WHEN: Get USD price
-      const price = await usdRepositoryRedis.getUsdPrice(
+      const price = await usdRepositoryCache.getUsdPrice(
         SupportedChainId.MAINNET,
         WETH
       );
@@ -62,7 +64,7 @@ describe('UsdRepositoryRedis', () => {
       proxyMock.getUsdPrice.mockResolvedValue(200);
 
       // WHEN: Get USD price
-      const price = await usdRepositoryRedis.getUsdPrice(
+      const price = await usdRepositoryCache.getUsdPrice(
         SupportedChainId.MAINNET,
         WETH
       );
@@ -80,7 +82,7 @@ describe('UsdRepositoryRedis', () => {
       proxyMock.getUsdPrice.mockResolvedValue(200);
 
       // When: Get USD price
-      const price = await usdRepositoryRedis.getUsdPrice(
+      const price = await usdRepositoryCache.getUsdPrice(
         SupportedChainId.MAINNET,
         WETH
       );
@@ -111,7 +113,7 @@ describe('UsdRepositoryRedis', () => {
       proxyMock.getUsdPrice.mockResolvedValue(null);
 
       // When: Get USD price
-      const price = await usdRepositoryRedis.getUsdPrice(
+      const price = await usdRepositoryCache.getUsdPrice(
         SupportedChainId.MAINNET,
         WETH
       );
@@ -144,7 +146,7 @@ describe('UsdRepositoryRedis', () => {
       });
 
       // When: Get USD price
-      const price = await usdRepositoryRedis.getUsdPrice(
+      const price = await usdRepositoryCache.getUsdPrice(
         SupportedChainId.MAINNET,
         WETH
       );
@@ -164,7 +166,7 @@ describe('UsdRepositoryRedis', () => {
       });
 
       // When: Get USD price
-      const pricePromise = usdRepositoryRedis.getUsdPrice(
+      const pricePromise = usdRepositoryCache.getUsdPrice(
         SupportedChainId.MAINNET,
         WETH
       );
@@ -202,7 +204,7 @@ describe('UsdRepositoryRedis', () => {
       proxyMock.getUsdPrices.mockResolvedValue([pricePoint200]);
 
       // WHEN: Get USD prices
-      const prices = await usdRepositoryRedis.getUsdPrices(
+      const prices = await usdRepositoryCache.getUsdPrices(
         SupportedChainId.MAINNET,
         WETH,
         '5m'
@@ -219,7 +221,7 @@ describe('UsdRepositoryRedis', () => {
       proxyMock.getUsdPrices.mockResolvedValue([pricePoint200]);
 
       // WHEN: Get USD prices
-      const prices = await usdRepositoryRedis.getUsdPrices(
+      const prices = await usdRepositoryCache.getUsdPrices(
         SupportedChainId.MAINNET,
         WETH,
         '5m'
@@ -238,7 +240,7 @@ describe('UsdRepositoryRedis', () => {
       proxyMock.getUsdPrices.mockResolvedValue([pricePoint200]);
 
       // When: Get USD prices
-      const prices = await usdRepositoryRedis.getUsdPrices(
+      const prices = await usdRepositoryCache.getUsdPrices(
         SupportedChainId.MAINNET,
         WETH,
         '5m'
@@ -271,7 +273,7 @@ describe('UsdRepositoryRedis', () => {
       proxyMock.getUsdPrices.mockResolvedValue(null);
 
       // When: Get USD prices
-      const prices = await usdRepositoryRedis.getUsdPrices(
+      const prices = await usdRepositoryCache.getUsdPrices(
         SupportedChainId.MAINNET,
         WETH,
         '5m'
@@ -306,7 +308,7 @@ describe('UsdRepositoryRedis', () => {
       });
 
       // When: Get USD price
-      const prices = await usdRepositoryRedis.getUsdPrices(
+      const prices = await usdRepositoryCache.getUsdPrices(
         SupportedChainId.MAINNET,
         WETH,
         '5m'
@@ -327,7 +329,7 @@ describe('UsdRepositoryRedis', () => {
       });
 
       // When: Get USD prices
-      const pricesPromise = usdRepositoryRedis.getUsdPrices(
+      const pricesPromise = usdRepositoryCache.getUsdPrices(
         SupportedChainId.MAINNET,
         WETH,
         '5m'

--- a/libs/repositories/src/UsdRepository/UsdRepositoryCache.ts
+++ b/libs/repositories/src/UsdRepository/UsdRepositoryCache.ts
@@ -1,17 +1,18 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import {
   PricePoint,
   PriceStrategy,
   UsdRepository,
   deserializePricePoints,
   serializePricePoints,
+  usdRepositorySymbol,
 } from './UsdRepository';
 import { SupportedChainId } from '../types';
 import IORedis from 'ioredis';
 import ms from 'ms';
 import { CacheRepository } from '../CacheRepository/CacheRepository';
 
-const DEFAULT_CACHE_VALUE_SECONDS = ms('2min') / 1000; // 2min cache time by default for values
+const DEFAULT_CACHE_VALUE_SECONDS = ms('10s') / 1000; // 2min cache time by default for values
 const DEFAULT_CACHE_NULL_SECONDS = ms('30min') / 1000; // 2min cache time by default for NULL values (when the repository don't know)
 const NULL_VALUE = 'null';
 
@@ -21,7 +22,7 @@ export class UsdRepositoryCache implements UsdRepository {
 
   constructor(
     private proxy: UsdRepository,
-    private cache: CacheRepository,
+    @inject(usdRepositorySymbol) private cache: CacheRepository,
     private cacheName: string,
     private cacheTimeValueSeconds: number = DEFAULT_CACHE_VALUE_SECONDS,
     private cacheTimeNullSeconds: number = DEFAULT_CACHE_NULL_SECONDS
@@ -38,7 +39,7 @@ export class UsdRepositoryCache implements UsdRepository {
     // Get price from cache
     const usdPriceCached = await this.getValueFromCache({
       key,
-      convertFn: parseInt,
+      convertFn: parseFloat,
     });
 
     if (usdPriceCached !== undefined) {

--- a/libs/repositories/src/UsdRepository/UsdRepositoryCache.ts
+++ b/libs/repositories/src/UsdRepository/UsdRepositoryCache.ts
@@ -9,18 +9,19 @@ import {
 import { SupportedChainId } from '../types';
 import IORedis from 'ioredis';
 import ms from 'ms';
+import { CacheRepository } from '../CacheRepository/CacheRepository';
 
 const DEFAULT_CACHE_VALUE_SECONDS = ms('2min') / 1000; // 2min cache time by default for values
 const DEFAULT_CACHE_NULL_SECONDS = ms('30min') / 1000; // 2min cache time by default for NULL values (when the repository don't know)
 const NULL_VALUE = 'null';
 
 @injectable()
-export class UsdRepositoryRedis implements UsdRepository {
+export class UsdRepositoryCache implements UsdRepository {
   private baseCacheKey: string;
 
   constructor(
     private proxy: UsdRepository,
-    private redisClient: IORedis,
+    private cache: CacheRepository,
     private cacheName: string,
     private cacheTimeValueSeconds: number = DEFAULT_CACHE_VALUE_SECONDS,
     private cacheTimeNullSeconds: number = DEFAULT_CACHE_NULL_SECONDS
@@ -96,9 +97,7 @@ export class UsdRepositoryRedis implements UsdRepository {
   }): Promise<T | null | undefined> {
     const { key, convertFn } = props;
 
-    const valueString = await this.redisClient.get(
-      this.baseCacheKey + ':' + key
-    );
+    const valueString = await this.cache.get(this.baseCacheKey + ':' + key);
     if (valueString) {
       return valueString === NULL_VALUE ? null : convertFn(valueString);
     }
@@ -115,10 +114,9 @@ export class UsdRepositoryRedis implements UsdRepository {
     const cacheTimeSeconds =
       value === null ? this.cacheTimeNullSeconds : this.cacheTimeValueSeconds;
 
-    await this.redisClient.set(
+    await this.cache.set(
       this.baseCacheKey + ':' + key,
       value === null ? NULL_VALUE : value,
-      'EX',
       cacheTimeSeconds
     );
   }

--- a/libs/repositories/src/index.ts
+++ b/libs/repositories/src/index.ts
@@ -1,5 +1,8 @@
 export * from './UsdRepository/UsdRepository';
 export * from './UsdRepository/UsdRepositoryCoingecko';
+export * from './UsdRepository/UsdRepositoryCow';
+export * from './UsdRepository/UsdRepositoryFallback';
+export * from './UsdRepository/UsdRepositoryRedis';
 export * from './types';
 export * from './datasources/redis';
 export { COINGECKO_PRO_BASE_URL } from './datasources/coingecko';

--- a/libs/repositories/src/index.ts
+++ b/libs/repositories/src/index.ts
@@ -1,8 +1,17 @@
+export * from './types';
+export * from './datasources/redis';
+
+// Data sources
+export { COINGECKO_PRO_BASE_URL } from './datasources/coingecko';
+
+// Cache repositories
+export * from './CacheRepository/CacheRepository';
+export * from './CacheRepository/CacheRepositoryMemory';
+export * from './CacheRepository/CacheRepositoryRedis';
+
+// USD repositories
 export * from './UsdRepository/UsdRepository';
 export * from './UsdRepository/UsdRepositoryCoingecko';
 export * from './UsdRepository/UsdRepositoryCow';
 export * from './UsdRepository/UsdRepositoryFallback';
-export * from './UsdRepository/UsdRepositoryRedis';
-export * from './types';
-export * from './datasources/redis';
-export { COINGECKO_PRO_BASE_URL } from './datasources/coingecko';
+export * from './UsdRepository/UsdRepositoryCache';

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "json-schema-to-ts": "^2.9.1",
     "ms": "^2.1.3",
     "mustache": "^4.2.0",
+    "node-cache": "^5.1.2",
     "node-fetch": "^3.3.2",
     "node-telegram-bot-api": "^0.65.1",
     "openapi-fetch": "^0.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3901,7 +3901,7 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-clone@^2.1.1:
+clone@2.x, clone@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
@@ -6693,6 +6693,13 @@ node-addon-api@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
 
 node-domexception@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR puts together all the repositories I was making for USD :) 

Basically, the endpoint service was exposed in the previous PR https://github.com/cowprotocol/bff/pull/60

## Secuence strategy with caching
This PR will make use of
- `UsdRepositoryFallback`: Will try first coingecko, and fallback in COW using native prices
- coingecko
    - will be using `UsdRepositoryRedis` for caching
    - And `UsdRepositoryCoingecko` for the implementation
- similarly, cow native USD price will use
    - will be using `UsdRepositoryRedis` for caching
    - And `UsdRepositoryCow` for the implementation 


## Caching logic
Additionally, the UsdRepositoryRedis has been refactor to... not be dependant on Redis. 

I did this just to make it easier to run the app with caching logic but not depend on having a redis running. I implement the most simple interface for a KeyValue store of strings. This way we can decouple the caching logic of the caching implementation.

I also adapted the tests.

## Not included
Pending, implement something to get the decimals


## Test
Make sure the endpoint now is making use of the new config

 curl http://localhost:3010/1/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/usdPrice