### PR TITLE
Implement mock slippage for backwards compatibility

### DIFF
--- a/apps/api/src/app/inversify.config.ts
+++ b/apps/api/src/app/inversify.config.ts
@@ -7,7 +7,7 @@ import {
 import { Container } from 'inversify';
 import {
   SlippageService,
-  SlippageServiceMain,
+  SlippageServiceMock,
   UsdService,
   UsdServiceMain,
   slippageServiceSymbol,
@@ -24,6 +24,6 @@ apiContainer
 // Services
 apiContainer
   .bind<SlippageService>(slippageServiceSymbol)
-  .to(SlippageServiceMain);
+  .to(SlippageServiceMock);
 
 apiContainer.bind<UsdService>(usdServiceSymbol).to(UsdServiceMain);

--- a/libs/services/src/SlippageService/SlippageService.ts
+++ b/libs/services/src/SlippageService/SlippageService.ts
@@ -1,12 +1,3 @@
-import {
-  UsdRepository,
-  usdRepositorySymbol,
-  SupportedChainId,
-} from '@cowprotocol/repositories';
-import { injectable, inject } from 'inversify';
-
-const DEFAULT_SLIPPAGE_BPS = 200;
-
 /**
  * BPS (Basis Points)
  */
@@ -20,43 +11,3 @@ export interface SlippageService {
 }
 
 export const slippageServiceSymbol = Symbol.for('SlippageService');
-
-@injectable()
-export class SlippageServiceMain implements SlippageService {
-  constructor(
-    @inject(usdRepositorySymbol)
-    private usdRepository: UsdRepository
-  ) {}
-
-  async getSlippageBps(
-    quoteTokenAddress: string,
-    baseTokenAddress: string
-  ): Promise<Bps> {
-    const [slippageQuoteToken, slippageBaseToken] = await Promise.all([
-      this.getSlippageForToken(quoteTokenAddress),
-      this.getSlippageForToken(baseTokenAddress),
-    ]);
-
-    return Math.max(slippageQuoteToken, slippageBaseToken);
-  }
-
-  private async getSlippageForToken(tokenAddress: string): Promise<number> {
-    const prices = await this.usdRepository.getUsdPrices(
-      SupportedChainId.MAINNET,
-      tokenAddress,
-      'daily'
-    );
-
-    if (!prices) {
-      return DEFAULT_SLIPPAGE_BPS;
-    }
-
-    const todayPrice = prices[prices.length - 1].price;
-    const yesterdayPrice = prices[prices.length - 2].price;
-    const bps = Math.abs(
-      ((todayPrice - yesterdayPrice) / yesterdayPrice) * 10000
-    );
-
-    return Math.ceil(bps);
-  }
-}

--- a/libs/services/src/SlippageService/SlippageServiceMain.spec.ts
+++ b/libs/services/src/SlippageService/SlippageServiceMain.spec.ts
@@ -1,9 +1,6 @@
 import { Container, injectable } from 'inversify';
-import {
-  SlippageService,
-  SlippageServiceImpl,
-  slippageServiceSymbol,
-} from './SlippageService';
+import { SlippageService, slippageServiceSymbol } from './SlippageService';
+import { SlippageServiceMain } from './SlippageServiceMain';
 import {
   PricePoint,
   PriceStrategy,
@@ -29,7 +26,7 @@ class UsdRepositoryMock implements UsdRepository {
   }
 }
 
-describe('SlippageService', () => {
+describe('SlippageServiceMain', () => {
   let slippageService: SlippageService;
 
   beforeAll(() => {
@@ -37,7 +34,7 @@ describe('SlippageService', () => {
     container.bind<UsdRepository>(usdRepositorySymbol).to(UsdRepositoryMock);
     container
       .bind<SlippageService>(slippageServiceSymbol)
-      .to(SlippageServiceImpl);
+      .to(SlippageServiceMain);
 
     slippageService = container.get(slippageServiceSymbol);
   });

--- a/libs/services/src/SlippageService/SlippageServiceMain.ts
+++ b/libs/services/src/SlippageService/SlippageServiceMain.ts
@@ -1,0 +1,49 @@
+import {
+  UsdRepository,
+  usdRepositorySymbol,
+  SupportedChainId,
+} from '@cowprotocol/repositories';
+import { injectable, inject } from 'inversify';
+import { Bps, SlippageService } from './SlippageService';
+
+const DEFAULT_SLIPPAGE_BPS = 200;
+
+@injectable()
+export class SlippageServiceMain implements SlippageService {
+  constructor(
+    @inject(usdRepositorySymbol)
+    private usdRepository: UsdRepository
+  ) {}
+
+  async getSlippageBps(
+    quoteTokenAddress: string,
+    baseTokenAddress: string
+  ): Promise<Bps> {
+    const [slippageQuoteToken, slippageBaseToken] = await Promise.all([
+      this.getSlippageForToken(quoteTokenAddress),
+      this.getSlippageForToken(baseTokenAddress),
+    ]);
+
+    return Math.max(slippageQuoteToken, slippageBaseToken);
+  }
+
+  private async getSlippageForToken(tokenAddress: string): Promise<number> {
+    const prices = await this.usdRepository.getUsdPrices(
+      SupportedChainId.MAINNET,
+      tokenAddress,
+      'daily'
+    );
+
+    if (!prices) {
+      return DEFAULT_SLIPPAGE_BPS;
+    }
+
+    const todayPrice = prices[prices.length - 1].price;
+    const yesterdayPrice = prices[prices.length - 2].price;
+    const bps = Math.abs(
+      ((todayPrice - yesterdayPrice) / yesterdayPrice) * 10000
+    );
+
+    return Math.ceil(bps);
+  }
+}

--- a/libs/services/src/SlippageService/SlippageServiceMock.ts
+++ b/libs/services/src/SlippageService/SlippageServiceMock.ts
@@ -1,0 +1,16 @@
+import { injectable } from 'inversify';
+import { Bps, SlippageService } from './SlippageService';
+
+const DEFAULT_SLIPPAGE_BPS = 50;
+
+@injectable()
+export class SlippageServiceMock implements SlippageService {
+  constructor() {}
+
+  async getSlippageBps(
+    _quoteTokenAddress: string,
+    _baseTokenAddress: string
+  ): Promise<Bps> {
+    return DEFAULT_SLIPPAGE_BPS;
+  }
+}

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -1,4 +1,5 @@
 export * from './SlippageService/SlippageService';
 export * from './SlippageService/SlippageServiceMain';
+export * from './SlippageService/SlippageServiceMock';
 
 export * from './UsdService/UsdService';

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -1,2 +1,4 @@
 export * from './SlippageService/SlippageService';
+export * from './SlippageService/SlippageServiceMain';
+
 export * from './UsdService/UsdService';


### PR DESCRIPTION
The previous implementation couldn't get to production, because it would change the default slippage tolerance used in CoW Swap.

This PR provides a temporal implementation, so we can keep working iteratively in having this service ready


<img width="1285" alt="image" src="https://github.com/user-attachments/assets/8d422c29-b917-42af-9eee-c36101d22903">


## Test

`curl http://localhost:3010/chains/1/markets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2-0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/slippageTolerance -v`
