### PR TITLE
chore: hotfix v0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "yarn start:api",
-    "start:api": "nx start",
+    "start:api": "nx start api",
     "twap:run-migrations": "nx run twap:run-migrations",
     "twap:generate-migrations": "nx run twap:generate-migrations",
     "producer": "nx run notification-producer:start",


### PR DESCRIPTION
# Summary

Changes based off of https://github.com/cowprotocol/bff/releases/tag/v0.6.3 which is the current prod version.

Pointing to the new branch `v0.6`.

It fixes the issue with cached responses.

The requests are being cached, but the cached part is the stream, not the the actual payload.
Since the stream is consumed in the first reply, the subsequent tries in the cached version return nothing:

```
"err":{"type":"FastifyError","message":"Reply was already sent.","stack":"FastifyError: Reply was already sent.\n    at _Reply.Reply.send (/Users/alfeto/work/cow/bff/node_modules/fastify/lib/reply.js:127:26)\n    at /Users/alfeto/work/cow/bff/node_modules/@fastify/reply-from/index.js:184:14\n    at /Users/alfeto/work/cow/bff/node_modules/@fastify/reply-from/index.js:277:9\n    at /Users/alfeto/work/cow/bff/node_modules/@fastify/reply-from/lib/request.js:173:7\n    at RequestHandler.runInAsyncScope (node:async_hooks:206:9)\n    at RequestHandler.onHeaders (/Users/alfeto/work/cow/bff/node_modules/undici/lib/api/api-request.js:105:14)\n    at Request.onHeaders (/Users/alfeto/work/cow/bff/node_modules/undici/lib/core/request.js:233:27)\n    at Parser.onHeadersComplete (/Users/alfeto/work/cow/bff/node_modules/undici/lib/client.js:794:23)\n    at wasm_on_headers_complete (/Users/alfeto/work/cow/bff/node_modules/undici/lib/client.js:408:30)\n    at null.<anonymous> (wasm://wasm/00036ac6:1:1173)","code":"FST_ERR_REP_ALREADY_SENT","name":"FastifyError","statusCode":500},"msg":"Reply already sent"}
```

Note: in order to properly consume and cache the payload, I had to disable the compression, similar to what I did in my first attempt at this https://github.com/cowprotocol/bff/pull/10/commits/55387a784d0698f45068027ab0ab565e3b069306