### PR TITLE
fix: use url as cache key which contains query params

### DIFF
--- a/apps/api/src/app/plugins/bffCache.ts
+++ b/apps/api/src/app/plugins/bffCache.ts
@@ -17,7 +17,7 @@ export const bffCache: FastifyPluginCallback<BffCacheOptions> = (fastify, opts, 
       return
     }
 
-    let key = getKey(request)
+    const key = getKey(request);
     // Remove it so we can cache it properly
     request.headers['accept-encoding'] = undefined;
 
@@ -59,7 +59,6 @@ export const bffCache: FastifyPluginCallback<BffCacheOptions> = (fastify, opts, 
       contents += chunk.toString(); // Process each chunk of data
     }
 
-
     const key = getKey(req);
     setCache(key, contents, cacheTtl, fastify).catch((e) => {
       fastify.log.error(`Error setting key ${key} from cache`, e);
@@ -74,7 +73,7 @@ export const bffCache: FastifyPluginCallback<BffCacheOptions> = (fastify, opts, 
 };
 
 function getKey(req: FastifyRequest) {
-  return `GET:${req.routerPath}`;
+  return `GET:${req.url}`;
 }
 
 function getTtlFromResponse(reply: FastifyReply, defaultTtl: number | undefined): number | undefined {


### PR DESCRIPTION
# Summary

Now that the caching was fixed on https://github.com/cowprotocol/bff/pull/67, the next issue was exposed.

Unfortunately I only noticed after it was already deployed to prod :(

Right now, the cache is the SAME for all requests.
That's because the cache key used in the request path: `req.routerPath` which is `/proxies/coingecko/*` for all requests.

Changed to `req.url` which does contain the full url path including the search params. E.g.: `/proxies/coingecko/simple/token_price/ethereum?contract_addresses=0x6B175474E89094C44Da98b954EedeAC495271d0F&vs_currencies=usd`

# Testing

1. Start the server locally with `yarn start`
2. Query one address: `curl -X GET http://localhost:3000/proxies/coingecko/simple/token_price/ethereum?contract_addresses=0x6B175474E89094C44Da98b954EedeAC495271d0F&vs_currencies=usd`
* Should receive the price for the asset
3. Query the same asset again
* Should receive the same response
4. Query a different asset: `curl -X GET http://localhost:3000/proxies/coingecko/simple/token_price/ethereum?contract_addresses=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&vs_currencies=usd`
* Should have a DIFFERENT price and the token address in the response should match the one in the query

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/853a50d3-e3af-497e-91a7-a585789ff060">
