### PR TITLE
Increase caching time

### DIFF
--- a/apps/api/src/app/inversify.config.ts
+++ b/apps/api/src/app/inversify.config.ts
@@ -12,6 +12,9 @@ import {
   usdRepositorySymbol,
 } from '@cowprotocol/repositories';
 
+const DEFAULT_CACHE_VALUE_SECONDS = ms('2min') / 1000; // 2min cache time by default for values
+const DEFAULT_CACHE_NULL_SECONDS = ms('30min') / 1000; // 30min cache time by default for NULL values (when the repository don't know)
+
 import { Container } from 'inversify';
 import {
   SlippageService,
@@ -21,6 +24,7 @@ import {
   slippageServiceSymbol,
   usdServiceSymbol,
 } from '@cowprotocol/services';
+import ms from 'ms';
 
 function getTokenDecimals(tokenAddress: string): number | null {
   return 18; // TODO: Implement!!!
@@ -38,7 +42,9 @@ function getUsdRepositoryCow(cacheRepository: CacheRepository): UsdRepository {
   return new UsdRepositoryCache(
     new UsdRepositoryCow(getTokenDecimals),
     cacheRepository,
-    'usdCow'
+    'usdCow',
+    DEFAULT_CACHE_VALUE_SECONDS,
+    DEFAULT_CACHE_NULL_SECONDS
   );
 }
 
@@ -48,7 +54,9 @@ function getUsdRepositoryCoingecko(
   return new UsdRepositoryCache(
     new UsdRepositoryCoingecko(),
     cacheRepository,
-    'usdCoingecko'
+    'usdCoingecko',
+    DEFAULT_CACHE_VALUE_SECONDS,
+    DEFAULT_CACHE_NULL_SECONDS
   );
 }
 

--- a/libs/repositories/src/UsdRepository/UsdRepositoryCache.ts
+++ b/libs/repositories/src/UsdRepository/UsdRepositoryCache.ts
@@ -40,14 +40,12 @@ export class UsdRepositoryCache implements UsdRepository {
     });
 
     if (usdPriceCached !== undefined) {
-      console.log('UsdRepositoryCache: Return cached', usdPriceCached);
       // Return cached price (if available)
       return usdPriceCached;
     }
 
     // Get the usd Price (delegate call)
     const usdPrice = await this.proxy.getUsdPrice(chainId, tokenAddress);
-    console.log('UsdRepositoryCache: not cached. Return FRESH 🥒', usdPrice);
 
     // Cache price (or absence of it)
     this.cacheValue({

--- a/libs/repositories/src/UsdRepository/UsdRepositoryCache.ts
+++ b/libs/repositories/src/UsdRepository/UsdRepositoryCache.ts
@@ -47,10 +47,7 @@ export class UsdRepositoryCache implements UsdRepository {
 
     // Get the usd Price (delegate call)
     const usdPrice = await this.proxy.getUsdPrice(chainId, tokenAddress);
-    console.log(
-      'UsdRepositoryCache: not cached. Return FRESH 🥒',
-      usdPriceCached
-    );
+    console.log('UsdRepositoryCache: not cached. Return FRESH 🥒', usdPrice);
 
     // Cache price (or absence of it)
     this.cacheValue({


### PR DESCRIPTION
This PR increases the caching time for values to 2min.

It also makes the specification of the caching time mandatory, and moves its const to the `inversify` configuration. 


## Test

To test, you can add some logs (you can apply this changes https://github.com/cowprotocol/bff/pull/71/commits/6aedf885ae3657bac8890dc6a12138dd3df7d833)

Then you can query the price of these tokens:

- curl -i  http://127.0.0.1:3010/1/tokens/0x6b175474e89094c44da98b954eedeac495271d0f/usdPrice
- curl -i  http://127.0.0.1:3010/1/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/usdPrice 


It might be handy to change the caching time to `10 seconds`  https://github.com/cowprotocol/bff/blob/increase-caching-time/apps/api/src/app/inversify.config.ts#L15

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/ff02e69d-8402-4acf-b4e7-3ed467aeb337">



