### PR TITLE
Fix caching issues

### DIFF
--- a/apps/api/src/app/plugins/bffCache.ts
+++ b/apps/api/src/app/plugins/bffCache.ts
@@ -6,11 +6,16 @@ import {
   parseCacheControlHeaderValue,
   setCache,
 } from '../../utils/cache';
-import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import {
+  FastifyInstance,
+  FastifyPluginCallback,
+  FastifyReply,
+  FastifyRequest,
+} from 'fastify';
 
 const HEADER_NAME = 'x-bff-cache';
-import { ReadableStream } from 'stream/web';
 import { getCacheKey } from '@cowprotocol/repositories';
+import { Readable } from 'stream';
 
 interface BffCacheOptions {
   ttl?: number;
@@ -28,17 +33,17 @@ export const bffCache: FastifyPluginCallback<BffCacheOptions> = (
       return;
     }
 
-    const key = getKey(request);
-    // Remove it so we can cache it properly
-    request.headers['accept-encoding'] = undefined;
+    let key = getKey(request);
 
     const cacheItem = await getCache(key, fastify).catch((e) => {
       fastify.log.error(`Error getting key ${key} from cache`, e);
-      return null;
+      return undefined;
     });
 
     if (cacheItem) {
       const { item, ttl } = cacheItem;
+      fastify.log.debug(`Found cached item "${item}" with TTL`, ttl);
+
       const ttlInSeconds = isNaN(ttl) ? undefined : Math.floor(ttl / 1000);
 
       if (ttlInSeconds !== undefined) {
@@ -49,43 +54,83 @@ export const bffCache: FastifyPluginCallback<BffCacheOptions> = (
         reply.header(HEADER_NAME, 'HIT');
         reply.type('application/json');
         reply.send(item);
-        return;
-      }
-    }
+        fastify.log.debug('onRequest cacheItem: %s (%d)', item, ttlInSeconds);
 
-    return;
+        return reply;
+      }
+    } else {
+      fastify.log.trace(`Request not cached for "${key}`);
+      // For now we don't add the cache 'MISS' header, because we only do this for cacheable endpoints (the ones that include cache-control header in the response)
+      // We need to handle this in the "onSend" once we know the actual response
+    }
   });
 
   fastify.addHook('onSend', async function (req, reply, payload) {
-    const isCacheHit = reply.getHeader(HEADER_NAME) === 'HIT';
-    const cacheTtl: number | undefined = getTtlFromResponse(reply, ttl);
-    const isStatus200 = reply.statusCode >= 200 && reply.statusCode < 300;
+    try {
+      const isCacheHit = reply.getHeader(HEADER_NAME) === 'HIT';
+      const cacheTtl: number | undefined = getTtlFromResponse(reply, ttl);
+      const isStatus200 = reply.statusCode >= 200 && reply.statusCode < 300;
 
-    // If the cache is a hit, or is non-cacheable, we just proceed with the request
-    if (isCacheHit || cacheTtl === undefined || !isStatus200) {
-      return;
+      // If the cache is a hit, or is non-cacheable, we just proceed with the request
+      if (isCacheHit || cacheTtl === undefined || !isStatus200) {
+        return undefined;
+      }
+
+      // If there is no cached data, then its a cache-miss
+      reply.header(HEADER_NAME, 'MISS');
+
+      // Get content from payload
+      const content =
+        typeof payload === 'string'
+          ? payload
+          : await getContentFromPayload(payload);
+
+      if (content !== null) {
+        // Cache (fire and forget)
+        const key = getKey(req);
+        setCache(key, content, cacheTtl, fastify).catch((e) => {
+          fastify.log.error(`Error setting key ${key} to cache`, e);
+        });
+        reply.header(
+          CACHE_CONTROL_HEADER,
+          getCacheControlHeaderValue(cacheTtl)
+        );
+        return content;
+      }
+    } catch (error) {
+      console.error('[bffCache] Error handling the cache', error);
     }
-
-    // If there is no cached data, then its a cache-miss
-    reply.header(HEADER_NAME, 'MISS');
-
-    let contents = '';
-    for await (const chunk of payload as ReadableStream) {
-      contents += chunk.toString(); // Process each chunk of data
-    }
-
-    const key = getKey(req);
-    setCache(key, contents, cacheTtl, fastify).catch((e) => {
-      fastify.log.error(`Error setting key ${key} from cache`, e);
-      return null;
-    });
-    reply.header(CACHE_CONTROL_HEADER, getCacheControlHeaderValue(cacheTtl));
-
-    return contents;
   });
 
   next();
 };
+
+async function getContentFromPayload(payload: unknown): Promise<string | null> {
+  if (payload instanceof Buffer) {
+    return payload.toString();
+  }
+
+  if (payload instanceof Response) {
+    return payload.text();
+  }
+
+  let contents = '';
+  if (payload instanceof Readable) {
+    for await (const chunk of payload) {
+      contents += chunk.toString();
+    }
+  } else if (payload instanceof ReadableStream) {
+    const reader = payload.getReader();
+    let result;
+    while (!(result = await reader.read()).done) {
+      contents += new TextDecoder().decode(result.value);
+    }
+  } else {
+    return null;
+  }
+
+  return contents;
+}
 
 function getKey(req: FastifyRequest) {
   return getCacheKey('requests', ...req.url.split('/'));

--- a/apps/api/src/app/routes/about.ts
+++ b/apps/api/src/app/routes/about.ts
@@ -3,12 +3,18 @@ import { FastifyPluginAsync } from 'fastify';
 
 import { readFileSync } from 'fs';
 const GIT_COMMIT_HASH_FILE = 'git-commit-hash.txt';
-const VERSION = process.env.VERSION || 'UNKNOWN, please set the environment variable';
+const VERSION =
+  process.env.VERSION || 'UNKNOWN, please set the environment variable';
 const COMMIT_HASH = getCommitHash();
 import { join } from 'path';
 import { server } from '../../main';
+import {
+  CACHE_CONTROL_HEADER,
+  getCacheControlHeaderValue,
+} from '../../utils/cache';
+import ms from 'ms';
 
-
+const CACHE_SECONDS = ms('10m') / 1000;
 
 interface AboutResponse {
   name: string;
@@ -17,26 +23,36 @@ interface AboutResponse {
 }
 
 const about: FastifyPluginAsync = async (fastify): Promise<void> => {
-  fastify.get<{ Reply: AboutResponse }>('/about', async function (_request, reply) {
-    return reply.send({
-      name: 'BFF API',
-      version: VERSION,
-      gitCommitHash: COMMIT_HASH,
-    });
-  });
+  fastify.get<{ Reply: AboutResponse }>(
+    '/about',
+    async function (_request, reply) {
+      reply.header(
+        CACHE_CONTROL_HEADER,
+        getCacheControlHeaderValue(CACHE_SECONDS)
+      );
+
+      return reply.send({
+        name: 'BFF API',
+        version: VERSION,
+        gitCommitHash: COMMIT_HASH,
+      });
+    }
+  );
 };
 
 /**
  * Read a file with the git commit hash (generated for example using github actions)
  */
 function getCommitHash(): string | undefined {
-  const filePath = join(__dirname, '../..', GIT_COMMIT_HASH_FILE)
+  const filePath = join(__dirname, '../..', GIT_COMMIT_HASH_FILE);
   try {
-    return readFileSync(filePath, 'utf-8')
+    return readFileSync(filePath, 'utf-8');
   } catch (error) {
-    // Not a big deal, if the file is not present, the about won't 
-    server.log.warn(`Unable to read the file with the git commit hash: ${filePath}. /about endpoint won't export the 'gitCommitHash'`);
-    return undefined
+    // Not a big deal, if the file is not present, the about won't
+    server.log.warn(
+      `Unable to read the file with the git commit hash: ${filePath}. /about endpoint won't export the 'gitCommitHash'`
+    );
+    return undefined;
   }
 }
 

--- a/libs/repositories/src/gen/cow/cow-api-types.ts
+++ b/libs/repositories/src/gen/cow/cow-api-types.ts
@@ -237,6 +237,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/orders/{UID}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the status of an order. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    UID: components["schemas"]["UID"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The order status with a list of solvers that proposed solutions (if applicable). */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CompetitionOrderStatus"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/transactions/{txHash}/orders": {
         parameters: {
             query?: never;
@@ -1309,6 +1347,21 @@ export interface components {
             orders?: components["schemas"]["UID"][];
             prices?: components["schemas"]["AuctionPrices"];
         };
+        ExecutedAmounts: {
+            sell: components["schemas"]["BigUint"];
+            buy: components["schemas"]["BigUint"];
+        };
+        CompetitionOrderStatus: {
+            /** @enum {string} */
+            type: "Open" | "Scheduled" | "Active" | "Solved" | "Executing" | "Traded" | "Cancelled";
+            /** @description A list of solvers who participated in the latest competition. The presence of executed amounts defines whether the solver provided a solution for the desired order.
+             *      */
+            value?: {
+                /** @description Name of the solver. */
+                solver: string;
+                executedAmounts?: components["schemas"]["ExecutedAmounts"];
+            }[];
+        };
         /** @description The reference prices for all traded tokens in the auction as a mapping from token
          *     addresses to a price denominated in native token (i.e. 1e18 represents a token that
          *     trades one to one with the native token). These prices are used for solution competition
@@ -1568,6 +1621,16 @@ export interface components {
             /** @description The call data to be used for the interaction. */
             call_data?: components["schemas"]["CallData"][];
         };
+        /** @description A calculated order quote.
+         *      */
+        Quote: {
+            /** @description The amount of the sell token. */
+            sellAmount?: components["schemas"]["TokenAmount"];
+            /** @description The amount of the buy token. */
+            buyAmount?: components["schemas"]["TokenAmount"];
+            /** @description The amount that needs to be paid, denominated in the sell token. */
+            fee?: components["schemas"]["TokenAmount"];
+        };
         /** @description The protocol fee is taken as a percent of the surplus. */
         Surplus: {
             factor: number;
@@ -1581,6 +1644,8 @@ export interface components {
         PriceImprovement: {
             factor: number;
             maxVolumeFactor: number;
+            /** @description The best quote received. */
+            quote: components["schemas"]["Quote"];
         };
         /** @description Defines the ways to calculate the protocol fee. */
         FeePolicy: components["schemas"]["Surplus"] | components["schemas"]["Volume"] | components["schemas"]["PriceImprovement"];

--- a/libs/repositories/src/utils/cache.ts
+++ b/libs/repositories/src/utils/cache.ts
@@ -1,5 +1,8 @@
 export type PartialCacheKey = string | number | boolean;
 
 export function getCacheKey(...params: PartialCacheKey[]) {
-  return params.map((param) => param.toString().toLowerCase()).join(':');
+  return params
+    .filter((item) => item !== '')
+    .map((param) => param.toString().toLowerCase())
+    .join(':');
 }


### PR DESCRIPTION
Freaking finally!! 

Fixed the cache 500 error I was getting for the slippage. 

## History
1. I implemented caching, made it work for the proxy (coingecko).
2. Then used it for caching JSON content responses from other endpoints. The medications made the caching to work for the JSON, but broke coingecko
3. Then Leandro noticed the error from Coingecko endpoint (we were caching a stream, not the content), and fixed it --> for coingecko, but broke it for our slippage endpoint

After this, I enter a dance of fixing it to one, breaking it to the other and so on. After a bit of struggling I think I manage to make it work in this PR

# Test

Run locally

## USD estimation
It doesn't have cache, so it won't have cache headers in the response
`curl http://127.0.0.1:3010/1/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/usdPrice`

```
 curl -i http://127.0.0.1:3010/1/tokens/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/usdPrice
HTTP/1.1 200 OK
vary: Origin
content-type: application/json; charset=utf-8
content-length: 17
Date: Fri, 02 Aug 2024 16:59:05 GMT
Connection: keep-alive
Keep-Alive: timeout=72
```

## Slippage
First request should be a MISS, the second should bi a HIT. Make sure content is alright

```
❯ curl -i http://localhost:3010/chains/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/slippageTolerance
HTTP/1.1 200 OK
vary: Origin
cache-control: max-age=120, public, s-maxage=120
content-type: application/json; charset=utf-8
x-bff-cache: MISS
content-length: 18
Date: Fri, 02 Aug 2024 17:00:09 GMT
Connection: keep-alive
Keep-Alive: timeout=72

{"slippageBps":50}%
❯ curl -i http://localhost:3010/chains/1/markets/0x6b175474e89094c44da98b954eedeac495271d0f-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/slippageTolerance
HTTP/1.1 200 OK
cache-control: max-age=117, public, s-maxage=117
x-bff-cache: HIT
content-type: application/json; charset=utf-8
content-length: 18
Date: Fri, 02 Aug 2024 17:00:12 GMT
Connection: keep-alive
Keep-Alive: timeout=72

{"slippageBps":50}%
```

## Coingecko
First request should be a MISS, the second should bi a HIT. Make sure content is alright

```
❯ curl -i http://localhost:3010/proxies/coingecko/simple/token_price/ethereum\?contract_addresses\=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\&vs_currencies\=usd
HTTP/1.1 200 OK
vary: Accept-Encoding, Origin
date: Fri, 02 Aug 2024 17:01:07 GMT
content-type: application/json; charset=utf-8
connection: keep-alive
x-frame-options: SAMEORIGIN
x-xss-protection: 0
x-content-type-options: nosniff
x-download-options: noopen
x-permitted-cross-domain-policies: none
referrer-policy: strict-origin-when-cross-origin
cache-control: max-age=3600, public, s-maxage=3600
access-control-allow-origin: *
access-control-allow-methods: POST, PUT, DELETE, GET, OPTIONS
access-control-request-method: *
access-control-allow-headers: Origin, X-Requested-With, Content-Type, Accept, Authorization
access-control-expose-headers: link, per-page, total
etag: W/"9d72d288fbc3cd015b4eb3067cfcd8ff"
x-request-id: 47beb2ad-0efd-4ee3-be06-2ca6eed9c9ff
x-runtime: 0.029064
alternate-protocol: 443:npn-spdy/2
strict-transport-security: max-age=15724800; includeSubdomains
x-bff-cache: MISS
content-length: 61

{"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2":{"usd":3027.2}}%
❯ curl -i http://localhost:3010/proxies/coingecko/simple/token_price/ethereum\?contract_addresses\=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\&vs_currencies\=usd
HTTP/1.1 200 OK
cache-control: max-age=3598, public, s-maxage=3598
x-bff-cache: HIT
content-type: application/json; charset=utf-8
content-length: 61
Date: Fri, 02 Aug 2024 17:01:08 GMT
Connection: keep-alive
Keep-Alive: timeout=72

{"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2":{"usd":3027.2}}%
```