### PR TITLE
Relax env configurations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # Version: Used in the /about endpoint. Useful to expose the Docker image version.
-LOG_LEVEL=info
-VESION=1.0.0
+# LOG_LEVEL=info
+# VESION=1.0.0
 
 # Port
-PORT=8080
+# PORT=8080
 
 # RPC urls (http or websocket)
 # RPC_URL_1=https://mainnet.infura.io/v3/your-infura-key
@@ -12,58 +12,58 @@ PORT=8080
 # RPC_URL_11155111=https://sepolia.infura.io/v3/your-infura-key
 
 # CoW API
-COW_API_BASE_URL=https://api.cow.fi
+# COW_API_BASE_URL=https://api.cow.fi
 # COW_API_URL_1=https://api.cow.fi/mainnet
 # COW_API_URL_100=https://api.cow.fi/xdai
 # COW_API_URL_42161=https://api.cow.fi/arbitrum_one
 # COW_API_URL_11155111=https://api.cow.fi/sepolia
 
 # Caching
-REDIS_HOST=redis
+# REDIS_HOST=redis
 # REDIS_PORT=6379
 # REDIS_USER=cow_redis
 # REDIS_PASSWORD=cow_password
 
 # Database
-DATABASE_USERNAME=bff-db-user
-DATABASE_PASSWORD=bff-db-password
-DATABASE_NAME=bff-db
-DATABASE_PORT=5432
+# DATABASE_USERNAME=bff-db-user
+# DATABASE_PASSWORD=bff-db-password
+# DATABASE_NAME=bff-db
+# DATABASE_PORT=5432
 
 # Rabbit MQ
-QUEUE_USER=rabbit
-QUEUE_PASSWORD=my-rabbit-password
-QUEUE_HOST=localhost
-QUEUE_PORT=5672
+#QUEUE_USER=rabbit
+#QUEUE_PASSWORD=my-rabbit-password
+#QUEUE_HOST=localhost
+#QUEUE_PORT=5672
 
 # Telegram
-TELEGRAM_SECRET=
+#TELEGRAM_SECRET=
 
 # Orderbook
-ORDERBOOK_DATABASE_HOST=
-ORDERBOOK_DATABASE_PORT=
-ORDERBOOK_DATABASE_USERNAME=
-ORDERBOOK_DATABASE_PASSWORD=
+#ORDERBOOK_DATABASE_HOST=
+#ORDERBOOK_DATABASE_PORT=
+#ORDERBOOK_DATABASE_USERNAME=
+#ORDERBOOK_DATABASE_PASSWORD=
 
 # CMS
-CMS_API_KEY=
-CMS_BASE_URL=https://cms.cow.fi
+#CMS_API_KEY=
+#CMS_BASE_URL=https://cms.cow.fi
 
 # Infura
-INFURA_KEY=infura-key
-INFURA_JWT_ID=infura-jwt-id
+#INFURA_KEY=infura-key
+#INFURA_JWT_ID=infura-jwt-id
 
 # Coingecko
-DEFAULT_COINGECKO_PROXY_UPSTREAM=https://api.coingecko.com
-COINGECKO_API_KEY=
-COINGECKO_CACHING_TIME=150
+#DEFAULT_COINGECKO_PROXY_UPSTREAM=https://api.coingecko.com
+#COINGECKO_API_KEY=
+#COINGECKO_CACHING_TIME=150
 
 # Proxy
-PROXY_UPSTREAM=proxy-upstream
-PROXY_ORIGIN=proxy-origin
+#PROXY_UPSTREAM=proxy-upstream
+#PROXY_ORIGIN=proxy-origin
 
 # JWT
-JWT_CERT_PASSPHRASE=secret
+# JWT_CERT_PASSPHRASE=secret
 
 # Authorized domains
-AUTHORIZED_ORIGINS=cow.fi
+# AUTHORIZED_ORIGINS=cow.fi

--- a/apps/api/src/app/plugins/env.ts
+++ b/apps/api/src/app/plugins/env.ts
@@ -3,7 +3,7 @@ import fp from 'fastify-plugin';
 
 const schema = {
   type: 'object',
-  required: ['PROXY_ORIGIN', 'PROXY_UPSTREAM', 'COINGECKO_API_KEY'],
+  required: [],
   properties: {
     LOG_LEVEL: {
       type: 'string',

--- a/apps/api/src/app/routes/accounts/_account/notifications.ts
+++ b/apps/api/src/app/routes/accounts/_account/notifications.ts
@@ -8,7 +8,7 @@ import { ETHEREUM_ADDRESS_PATTERN } from '../../../schemas';
 import {
   CACHE_CONTROL_HEADER,
   getCacheControlHeaderValue,
-} from 'apps/api/src/utils/cache';
+} from '../../../../utils/cache';
 import ms from 'ms';
 
 const CACHE_SECONDS = ms('5m') / 1000;

--- a/apps/api/src/app/routes/proxies/coingecko/index.ts
+++ b/apps/api/src/app/routes/proxies/coingecko/index.ts
@@ -17,10 +17,14 @@ const DROP_HEADERS: KeysOf<IncomingHttpHeaders>[] = [
 
 const CACHE_TTL = parseInt(process.env.COINGECKO_CACHING_TIME || '150'); // Defaults to 2.5 minutes (150 seconds)
 
-const coingeckoProxy: FastifyPluginAsync = async (
-  fastify,
-  opts
-): Promise<void> => {
+const coingeckoProxy: FastifyPluginAsync = async (fastify): Promise<void> => {
+  const coingeckoApiKey = fastify.config.COINGECKO_API_KEY;
+
+  if (!coingeckoApiKey) {
+    fastify.log.warn('COINGECKO_API_KEY is not set. Skipping proxy.');
+    return;
+  }
+
   fastify.register(httpProxy, {
     upstream: COINGECKO_PRO_BASE_URL,
     rewritePrefix: '/api/v3/',

--- a/apps/api/src/app/routes/proxies/tokens/index.ts
+++ b/apps/api/src/app/routes/proxies/tokens/index.ts
@@ -1,9 +1,15 @@
-import { FastifyPluginAsync } from "fastify";
-import httpProxy from "@fastify/http-proxy";
+import { FastifyPluginAsync } from 'fastify';
+import httpProxy from '@fastify/http-proxy';
 
 const proxy: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
+  const upstream = fastify.config.PROXY_UPSTREAM;
+  if (!upstream) {
+    fastify.log.warn('PROXY_UPSTREAM is not set. Skipping proxy.');
+    return;
+  }
+
   fastify.register(httpProxy, {
-    upstream: fastify.config.PROXY_UPSTREAM,
+    upstream,
     replyOptions: {
       rewriteRequestHeaders: (originalRequest: any, headers: any) => {
         return {

--- a/apps/api/src/app/routes/twap/index.ts
+++ b/apps/api/src/app/routes/twap/index.ts
@@ -1,9 +1,15 @@
-import { FastifyPluginAsync } from "fastify";
-import httpProxy from "@fastify/http-proxy";
+import { FastifyPluginAsync } from 'fastify';
+import httpProxy from '@fastify/http-proxy';
 
 const proxy: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
+  const upstream = fastify.config.TWAP_BASE_URL;
+  if (!upstream) {
+    fastify.log.warn('TWAP_BASE_URL is not set. Skipping proxy.');
+    return;
+  }
+
   fastify.register(httpProxy, {
-    upstream: fastify.config.TWAP_BASE_URL,
+    upstream,
   });
 };
 

--- a/libs/cms-api/src/index.ts
+++ b/libs/cms-api/src/index.ts
@@ -39,9 +39,13 @@ export interface NotificationModel {
 }
 
 const cmsBaseUrl = process.env.CMS_BASE_URL;
-assert(cmsBaseUrl, 'CMS_BASE_URL is required');
+
 const cmsApiKey = process.env.CMS_API_KEY;
-assert(cmsApiKey, 'CMS_API_KEY is required');
+if (!cmsApiKey) {
+  console.warn(
+    'CMS_API_KEY is not set. Some CMS integrations might not work for lack of permissions.'
+  );
+}
 
 const cmsClient = CmsClient({
   url: cmsBaseUrl,

--- a/libs/repositories/src/gen/cow/cow-api-types.ts
+++ b/libs/repositories/src/gen/cow/cow-api-types.ts
@@ -1353,7 +1353,7 @@ export interface components {
         };
         CompetitionOrderStatus: {
             /** @enum {string} */
-            type: "Open" | "Scheduled" | "Active" | "Solved" | "Executing" | "Traded" | "Cancelled";
+            type: "open" | "scheduled" | "active" | "solved" | "executing" | "traded" | "cancelled";
             /** @description A list of solvers who participated in the latest competition. The presence of executed amounts defines whether the solver provided a solution for the desired order.
              *      */
             value?: {


### PR DESCRIPTION
This PR relaxes the requirements for env configurations

It makes all envs optional providing fair default. 

For the proxies, if you don't pass the right env they won't be created. It will give you a warning though. 


It runs with no env file, it will give you just some relevant warn messages:
<img width="1565" alt="image" src="https://github.com/user-attachments/assets/8fd0a537-e9be-4550-9901-e82fde3acf83">
