### PR TITLE
Implement TTL and use our own repository to cache requests

### DIFF
--- a/apps/api/src/app/plugins/bffCache.ts
+++ b/apps/api/src/app/plugins/bffCache.ts
@@ -1,17 +1,10 @@
 import fp from 'fastify-plugin';
 import {
   CACHE_CONTROL_HEADER,
-  getCache,
   getCacheControlHeaderValue,
   parseCacheControlHeaderValue,
-  setCache,
 } from '../../utils/cache';
-import {
-  FastifyInstance,
-  FastifyPluginCallback,
-  FastifyReply,
-  FastifyRequest,
-} from 'fastify';
+import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
 
 const HEADER_NAME = 'x-bff-cache';
 import {

--- a/libs/repositories/src/CacheRepository/CacheRepository.ts
+++ b/libs/repositories/src/CacheRepository/CacheRepository.ts
@@ -2,5 +2,6 @@ export const cacheRepositorySymbol = Symbol.for('CacheRepository');
 
 export interface CacheRepository {
   get(key: string): Promise<string | null>;
+  getTtl(key: string): Promise<number | null>;
   set(key: string, value: string, ttl: number): Promise<void>;
 }

--- a/libs/repositories/src/CacheRepository/CacheRepositoryMemory.ts
+++ b/libs/repositories/src/CacheRepository/CacheRepositoryMemory.ts
@@ -12,6 +12,16 @@ export class CacheRepositoryMemory implements CacheRepository {
     return value ?? null;
   }
 
+  async getTtl(key: string): Promise<number | null> {
+    const ttlEpoch = (await CacheRepositoryMemory.cache.getTtl(key)) || null;
+
+    if (ttlEpoch === null) {
+      return null;
+    }
+
+    return Math.floor((ttlEpoch - Date.now()) / 1000);
+  }
+
   async set(key: string, value: string, ttl: number): Promise<void> {
     await CacheRepositoryMemory.cache.set(key, value, ttl);
   }

--- a/libs/repositories/src/CacheRepository/CacheRepositoryRedis.ts
+++ b/libs/repositories/src/CacheRepository/CacheRepositoryRedis.ts
@@ -1,12 +1,23 @@
 import { injectable } from 'inversify';
 import { CacheRepository } from './CacheRepository';
+import { Redis } from 'ioredis';
 
 @injectable()
 export class CacheRepositoryRedis implements CacheRepository {
-  constructor(private redisClient: any) {}
+  constructor(private redisClient: Redis) {}
 
   async get(key: string): Promise<string | null> {
     return this.redisClient.get(key);
+  }
+
+  async getTtl(key: string): Promise<number | null> {
+    const ttl = await this.redisClient.ttl(key);
+
+    if (ttl < 0) {
+      return null;
+    }
+
+    return ttl;
   }
 
   async set(key: string, value: string, ttl: number): Promise<void> {


### PR DESCRIPTION
This PR fixes the current issue with the keys in redis (the special characters are encoded)

See  these keys:
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/f8d0ecf3-b294-486f-acef-d713a4b14fa1">


I noticed that our cache repository don't have this behaviour, and this come from the abstract-cache. I just ditch it. Our repository is equivalent. I had to implement the TTL method, since we didn't have a way to get the expiration of keys. 


With that, it works as expected.

Tested with `curl -i http://localhost:3010/proxies/coingecko/simple/token_price/ethereum/\?contract_addresses\=0x6B175474E89094C44Da98b954EedeAC495271d0F\&vs_currencies\=usd`
![image](https://github.com/user-attachments/assets/d39c7fff-7c44-448f-a6d9-0c7bd49436aa)


