### PR TITLE
Fix simulation env var names on plugin

### DIFF
--- a/apps/api/src/app/plugins/env.ts
+++ b/apps/api/src/app/plugins/env.ts
@@ -29,10 +29,10 @@ const schema = {
     TENDERLY_API_KEY: {
       type: 'string',
     },
-    TENDERLY_PROJECT: {
+    TENDERLY_PROJECT_NAME: {
       type: 'string',
     },
-    TENDERLY_ACCOUNT: {
+    TENDERLY_ORG_NAME: {
       type: 'string',
     },
     ETHPLORER_API_KEY: {


### PR DESCRIPTION
Match the pattern used on the rest of the code (check .env.example)

To test:
- Run the API locally and test with the request:

```
curl --request POST \
  --url https://bff.barn.cow.fi/1/simulation/simulateBundle \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/10.0.0' \
  --data '[
{
  "from": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
  "to": "0x0000000000000000000000000000000000000000",
  "value": "1000000000000000000",
  "input": "0x"
}
]'
```