### PR TITLE
fix deep copy error on build balances diff

### DIFF
--- a/libs/repositories/src/SimulationRepository/SimulationRepositoryTenderly.ts
+++ b/libs/repositories/src/SimulationRepository/SimulationRepositoryTenderly.ts
@@ -113,7 +113,7 @@ export class SimulationRepositoryTenderly implements SimulationRepository {
         }
       });
 
-      return { ...cumulativeBalancesDiff };
+      return JSON.parse(JSON.stringify(cumulativeBalancesDiff));
     });
   }
 }


### PR DESCRIPTION
This fix is due to a last change in the previous PR. To test, run the automatic tests with:


`nx test repositories --testFile=libs/repositories/src/SimulationRepository/SimulationrepositoryTenderly.test.ts`