### PR TITLE
feat: add `gasUsed` data on tenderly simulation endpoint

### DIFF
--- a/apps/api/src/app/routes/__chainId/simulation/simulateBundle.ts
+++ b/apps/api/src/app/routes/__chainId/simulation/simulateBundle.ts
@@ -20,7 +20,7 @@ const successSchema = {
   type: 'array',
   items: {
     type: 'object',
-    required: ['status', 'id', 'link', 'cumulativeBalancesDiff'],
+    required: ['status', 'id', 'link', 'cumulativeBalancesDiff', 'gasUsed'],
     additionalProperties: false,
     properties: {
       status: {
@@ -48,6 +48,11 @@ const successSchema = {
             type: 'string',
           },
         },
+      },
+      gasUsed: {
+        title: 'Gas Used',
+        description: 'Amount of gas used in the transaction with decimals.',
+        type: 'string',
       },
     },
   },

--- a/libs/repositories/src/SimulationRepository/SimulationRepository.ts
+++ b/libs/repositories/src/SimulationRepository/SimulationRepository.ts
@@ -16,6 +16,7 @@ export interface SimulationData {
   // { [address: string]: { [token: string]: balanceDiff: string } }
   // example: { '0x123': { '0x456': '100', '0xabc': '-100' } }
   cumulativeBalancesDiff: Record<string, Record<string, string>>;
+  gasUsed: string;
 }
 
 export const simulationRepositorySymbol = Symbol.for('SimulationRepository');

--- a/libs/repositories/src/SimulationRepository/SimulationRepositoryTenderly.ts
+++ b/libs/repositories/src/SimulationRepository/SimulationRepositoryTenderly.ts
@@ -62,6 +62,7 @@ export class SimulationRepositoryTenderly implements SimulationRepository {
         id: simulation_result.simulation.id,
         link: getTenderlySimulationLink(simulation_result.simulation.id),
         cumulativeBalancesDiff: balancesDiff[i],
+        gasUsed: simulation_result.transaction.gas_used.toString(),
       };
     });
   }

--- a/libs/repositories/src/SimulationRepository/SimulationrepositoryTenderly.test.ts
+++ b/libs/repositories/src/SimulationRepository/SimulationrepositoryTenderly.test.ts
@@ -57,6 +57,7 @@ describe('SimulationRepositoryTenderly', () => {
       expect(tenderlySimulationResult).toBeDefined();
       expect(tenderlySimulationResult?.length).toBe(1);
       expect(tenderlySimulationResult?.[0].status).toBeTruthy();
+      expect(Number(tenderlySimulationResult?.[0].gasUsed)).toBeGreaterThan(0);
     }, 100000);
 
     it('should return null for invalid simulation', async () => {
@@ -79,6 +80,7 @@ describe('SimulationRepositoryTenderly', () => {
       expect(tenderlySimulationResult).toBeDefined();
       expect(tenderlySimulationResult?.length).toBe(1);
       expect(tenderlySimulationResult?.[0].status).toBeFalsy();
+      expect(Number(tenderlySimulationResult?.[0].gasUsed)).toBeGreaterThan(0);
     }, 100000);
   });
   describe('buildBalancesDiff', () => {


### PR DESCRIPTION
Run the automatic tests with:

`nx test repositories --testFile=libs/repositories/src/SimulationRepository/SimulationrepositoryTenderly.test.ts`

By the way, as you can see the gas parameter is returned even in failed simulations, so maybe we don't need to make the hook app pass a `maxGasLimit` parameter.