### PR TITLE
fix: change tenderly transaction type to optional on tenderly simulation

### DIFF
--- a/libs/repositories/src/SimulationRepository/SimulationRepository.ts
+++ b/libs/repositories/src/SimulationRepository/SimulationRepository.ts
@@ -16,7 +16,7 @@ export interface SimulationData {
   // { [address: string]: { [token: string]: balanceDiff: string } }
   // example: { '0x123': { '0x456': '100', '0xabc': '-100' } }
   cumulativeBalancesDiff: Record<string, Record<string, string>>;
-  gasUsed: string;
+  gasUsed?: string;
 }
 
 export const simulationRepositorySymbol = Symbol.for('SimulationRepository');

--- a/libs/repositories/src/SimulationRepository/SimulationRepositoryTenderly.ts
+++ b/libs/repositories/src/SimulationRepository/SimulationRepositoryTenderly.ts
@@ -52,7 +52,7 @@ export class SimulationRepositoryTenderly implements SimulationRepository {
 
     const balancesDiff = this.buildBalancesDiff(
       response.simulation_results.map(
-        (result) => result.transaction.transaction_info.asset_changes || []
+        (result) => result.transaction?.transaction_info.asset_changes || []
       )
     );
 
@@ -62,7 +62,7 @@ export class SimulationRepositoryTenderly implements SimulationRepository {
         id: simulation_result.simulation.id,
         link: getTenderlySimulationLink(simulation_result.simulation.id),
         cumulativeBalancesDiff: balancesDiff[i],
-        gasUsed: simulation_result.transaction.gas_used.toString(),
+        gasUsed: simulation_result.transaction?.gas_used.toString(),
       };
     });
   }

--- a/libs/repositories/src/SimulationRepository/tenderlyTypes.ts
+++ b/libs/repositories/src/SimulationRepository/tenderlyTypes.ts
@@ -57,7 +57,7 @@ export type TenderlySimulatePayload = {
 // certainly not entirely accurate (and they have some interesting type names)
 
 export interface TenderlySimulation {
-  transaction: Transaction;
+  transaction?: Transaction;
   simulation: Simulation;
   contracts: TenderlyContract[];
   generated_access_list: GeneratedAccessList[];


### PR DESCRIPTION
This PR only changes the type to optional and returns the null gas used since the value will not be presented