### PR TITLE
feat: allow to pretty-print in production

### DIFF
--- a/apps/api/src/logger.ts
+++ b/apps/api/src/logger.ts
@@ -2,16 +2,25 @@ import pino from 'pino';
 
 export type Logger = pino.Logger;
 
-const loggerConfigEnv =
-  process.env.NODE_ENV === 'production'
-    ? {}
-    : {
+function getLogger() {
+  // Uses pretty print if LOGGER is set to 'pretty'. By default, it will also use it for non-production environments.
+  // If the LOGGER is not pretty, it defaults to a JSON logger.
+  const usePrettyPrint = process.env.LOGGER
+    ? process.env.LOGGER === 'pretty'
+    : process.env.NODE_ENV !== 'production';
+
+  const loggerConfigEnv = usePrettyPrint
+    ? {
         transport: {
           target: 'pino-pretty',
         },
-      };
+      }
+    : {};
 
-export const logger = pino({
-  ...loggerConfigEnv,
-  level: process.env.LOG_LEVEL ?? 'info',
-});
+  return pino({
+    ...loggerConfigEnv,
+    level: process.env.LOG_LEVEL ?? 'info',
+  });
+}
+
+export const logger = getLogger();


### PR DESCRIPTION
This PR allows allows to control the logger, so you can choose in any environment if you want to use the pretty-print logger or the JSON one.

This control is done with a new env var called `LOGGER`.

The config Its backward compatible, because if you don't provide the env, then it will default to use pretty-print for non-production environments, and JSON-print otherwise (which was the older behaviour).

## Pretty print vs JSON print

Pretty print is nice for developing:
<img width="692" alt="image" src="https://github.com/user-attachments/assets/c53cb65f-6033-46cb-8702-0322c84987f5" />

JSON print is nice for production:
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/be5e1109-d165-4046-a996-b634f60d9bf5" />

## Test
Make sure its backward compatible. The following command should use JSON:
`LOGGER= NODE_ENV=production yarn start:api`

The following pretty-prints:
`LOGGER= NODE_ENV=development yarn start:api`

Test that we can now pretty-print in production:
`LOGGER=pretty NODE_ENV=production yarn start:api`
