### PR TITLE
fix: do not assume 18 decimals when it can't be fetched

### DIFF
--- a/libs/repositories/src/UsdRepository/UsdRepositoryCow.spec.ts
+++ b/libs/repositories/src/UsdRepository/UsdRepositoryCow.spec.ts
@@ -210,15 +210,13 @@ describe('UsdRepositoryCow', () => {
       );
 
       // Get USD price for a token without decimals
-      const pricePromise = usdRepositoryCow.getUsdPrice(
+      const price = await usdRepositoryCow.getUsdPrice(
         SupportedChainId.MAINNET,
         WETH
       );
 
-      // Should throw error about missing decimals
-      await expect(pricePromise).rejects.toThrow(
-        'Token decimals not found for ' + WETH
-      );
+      // Should return null when missing decimals
+      expect(price).toBe(null);
     });
   });
 

--- a/libs/repositories/src/UsdRepository/UsdRepositoryCow.ts
+++ b/libs/repositories/src/UsdRepository/UsdRepositoryCow.ts
@@ -27,8 +27,10 @@ export class UsdRepositoryCow extends UsdRepositoryNoop {
     }
     const erc20 = await this.erc20Repository.get(chainId, tokenAddress);
     const tokenDecimals = erc20?.decimals;
+
     if (tokenDecimals === undefined) {
-      throw new Error('Token decimals not found for ' + tokenAddress);
+      console.info('Token decimals not found for ' + tokenAddress);
+      return null;
     }
 
     // Get native price for USDC (in ETH/xDAI)

--- a/libs/repositories/src/UsdRepository/UsdRepositoryCow.ts
+++ b/libs/repositories/src/UsdRepository/UsdRepositoryCow.ts
@@ -1,11 +1,11 @@
-import { injectable } from 'inversify';
-import { UsdRepositoryNoop } from './UsdRepository';
-import { OneBigNumber, TenBigNumber, USDC, ZeroBigNumber } from '../const';
 import { SupportedChainId } from '@cowprotocol/shared';
 import { BigNumber } from 'bignumber.js';
-import { throwIfUnsuccessful } from '../utils/throwIfUnsuccessful';
+import { injectable } from 'inversify';
 import { Erc20Repository } from '../Erc20Repository/Erc20Repository';
+import { OneBigNumber, TenBigNumber, USDC, ZeroBigNumber } from '../const';
 import { CowApiClient } from '../datasources/cowApi';
+import { throwIfUnsuccessful } from '../utils/throwIfUnsuccessful';
+import { UsdRepositoryNoop } from './UsdRepository';
 
 @injectable()
 export class UsdRepositoryCow extends UsdRepositoryNoop {
@@ -26,8 +26,8 @@ export class UsdRepositoryCow extends UsdRepositoryNoop {
       return null;
     }
     const erc20 = await this.erc20Repository.get(chainId, tokenAddress);
-    const tokenDecimals = erc20?.decimals || 18;
-    if (tokenDecimals === null) {
+    const tokenDecimals = erc20?.decimals;
+    if (tokenDecimals === undefined) {
       throw new Error('Token decimals not found for ' + tokenAddress);
     }
 


### PR DESCRIPTION
# Summary

Do not assume token has 18 decimals when the values can't be fetched from the contract.
It can have unwanted consequences, like a bad token estimation.

When not found, return a 400.

# Testing

- Added unit tests.