### PR TITLE
Get susbcribed users and create draft for trade event producer

### DIFF
--- a/apps/notification-producer/src/SubscriptionsRepository.ts
+++ b/apps/notification-producer/src/SubscriptionsRepository.ts
@@ -1,0 +1,21 @@
+import { getAllSubscribedAccounts } from '@cowprotocol/cms-api';
+
+const CACHE_TIME = 30000;
+
+// TODO: Move to repositories and make a proper cached repository and use DI
+export class SubscriptionRepository {
+  private lastCheck: number | null = null;
+  private cachedAccounts: string[] | null = null;
+
+  async getAllSubscribedAccounts(): Promise<string[]> {
+    const now = Date.now();
+    if (!this.lastCheck || now - this.lastCheck > CACHE_TIME) {
+      this.cachedAccounts = Array.from(
+        new Set(await getAllSubscribedAccounts())
+      );
+      this.lastCheck = now;
+      return this.cachedAccounts;
+    }
+    return this.cachedAccounts || [];
+  }
+}

--- a/apps/notification-producer/src/main.ts
+++ b/apps/notification-producer/src/main.ts
@@ -1,6 +1,8 @@
 import { Runnable } from '../types';
 import { NotificationsRepository } from './NotificationsRepository';
 import { CmsNotificationProducer } from './producers/CmsNotificationProducer';
+import { TradeNotificationProducer } from './producers/TradeNotificationProducer';
+import { SubscriptionRepository } from './SubscriptionsRepository';
 
 /**
  * Main loop: Run and re-attempt on error
@@ -10,11 +12,18 @@ async function mainLoop() {
 
   // TODO: Move to DI
   const notificationsRepository = new NotificationsRepository();
+  const subscriptionRepository = new SubscriptionRepository();
+
+  const repositories = {
+    notificationsRepository,
+    subscriptionRepository,
+  };
 
   // Create all producers
   const producers: Runnable[] = [
     // CMS producer: Fetch PUSH notifications
-    new CmsNotificationProducer(notificationsRepository),
+    new CmsNotificationProducer(repositories),
+    new TradeNotificationProducer(repositories),
   ];
 
   const promises = [];

--- a/apps/notification-producer/src/producers/TradeNotificationProducer.ts
+++ b/apps/notification-producer/src/producers/TradeNotificationProducer.ts
@@ -1,0 +1,64 @@
+import { Notification } from '@cowprotocol/notifications';
+import { NotificationsRepository } from '../NotificationsRepository';
+import { doForever } from '../utils';
+
+import { Runnable } from '../../types';
+import { SubscriptionRepository } from '../SubscriptionsRepository';
+
+const WAIT_TIME = 30000;
+
+export type TradeNotificationProducerProps = {
+  notificationsRepository: NotificationsRepository;
+  subscriptionRepository: SubscriptionRepository;
+};
+
+export class TradeNotificationProducer implements Runnable {
+  /**
+   * This in-memory state just adds some resilience in case there's an error posting the message.
+   * Because the PUSH notifications are currently consumed just by reading, in case of a failure the notification is lost
+   *
+   * This solution is a patch until we properly implement a more reliable consumption
+   */
+  pendingNotifications = new Map<string, Notification>();
+
+  constructor(private props: TradeNotificationProducerProps) {}
+
+  /**
+   * Main loop: Run the CMS notification producer. This method runs indefinitely,
+   * fetching notifications and sending them to the queue.
+   *
+   * The method should not throw or finish.
+   */
+  async start(): Promise<void> {
+    doForever(
+      'TradeNotificationProducer',
+      async () => {
+        await this.fetchAndSend();
+      },
+      WAIT_TIME
+    );
+  }
+
+  async fetchAndSend(): Promise<void> {
+    // Get last indexed block
+    // TODO:
+    // Get last block
+    // TODO:
+    // Get trade events from block to last block
+    // TODO:
+    // Filter events, only keep relevant ones
+    // TODO:
+    // Convert events to notifications
+    // TODO:
+    // Send notifications
+    // TODO:
+
+    const accounts =
+      await this.props.subscriptionRepository.getAllSubscribedAccounts();
+
+    console.log(
+      'For now, nothing to do. I plan to fetch trades for: ' +
+        accounts.join(', ')
+    );
+  }
+}

--- a/libs/cms-api/src/index.ts
+++ b/libs/cms-api/src/index.ts
@@ -1,5 +1,4 @@
 import { CmsClient, components } from '@cowprotocol/cms';
-import assert from 'assert';
 
 type Schemas = components['schemas'];
 export type CmsNotification = Schemas['NotificationListResponseDataItem'];
@@ -137,31 +136,50 @@ async function getNotificationsPage({
   return data.data;
 }
 
+export async function getAllSubscribedAccounts(): Promise<string[]> {
+  return getAllPages({
+    pageSize: PAGE_SIZE,
+    getPage: (params) => getSubscribedAccounts(params),
+  });
+}
+
 export async function getAllTelegramSubscriptionsForAccounts(
   accounts: string[]
 ): Promise<CmsTelegramSubscription[]> {
+  return getAllPages({
+    pageSize: PAGE_SIZE,
+    getPage: (params) =>
+      getTelegramSubscriptionsForAccounts({
+        ...params,
+        accounts,
+      }),
+  });
+}
+
+async function getAllPages<T>({
+  pageSize = PAGE_SIZE,
+  getPage,
+}: PaginationParam & {
+  getPage: (params: PaginationParam) => Promise<T[]>;
+}): Promise<T[]> {
   const allSubscriptions = [];
   let page = 0;
 
-  let subscriptions = await getTelegramSubscriptionsForAccounts({
+  let subscriptions = await getPage({
     page,
-    pageSize: PAGE_SIZE + 1,
-    accounts,
+    pageSize: pageSize + 1,
   }); // Get one extra to check if there's more pages
 
   allSubscriptions.push(
-    subscriptions.length > PAGE_SIZE
-      ? subscriptions.slice(0, -1)
-      : subscriptions
+    subscriptions.length > pageSize ? subscriptions.slice(0, -1) : subscriptions
   );
 
-  while (subscriptions.length > PAGE_SIZE) {
-    subscriptions = await getTelegramSubscriptionsForAccounts({
+  while (subscriptions.length > pageSize) {
+    subscriptions = await getPage({
       page,
-      pageSize: PAGE_SIZE + 1,
-      accounts,
+      pageSize: pageSize + 1,
     }); // Get one extra to check if there's more pages
-    const hasMorePages = subscriptions.length > PAGE_SIZE;
+    const hasMorePages = subscriptions.length > pageSize;
     allSubscriptions.push(
       hasMorePages ? subscriptions.slice(0, -1) : subscriptions
     );
@@ -202,6 +220,27 @@ async function getTelegramSubscriptionsForAccounts({
   }
 
   return data;
+}
+
+async function getSubscribedAccounts({
+  page = 0,
+  pageSize = PAGE_SIZE,
+}: PaginationParam): Promise<string[]> {
+  const { data, error, response } = await cmsClient.GET(`/tg-subscriptions`, {
+    // Pagination
+    'pagination[page]': page,
+    'pagination[pageSize]': pageSize,
+  });
+
+  if (error) {
+    console.error(
+      `Error ${response.status} getting telegram subscriptions: ${response.url}. Page${page}`,
+      error
+    );
+    throw error;
+  }
+
+  return (data as CmsTelegramSubscription[]).map(({ account }) => account);
 }
 
 export async function getPushNotifications(): Promise<CmsPushNotification[]> {


### PR DESCRIPTION
This PR creates

## SubscriptionsRepository
For now only used to get the relevant accounts. This repository needs caching because its used by multiple producers. For now I implement it easily with a basic in-memory caching, but should follow our repo structure and use our cache repository to take full advantage of our current infra REDIS/in-memory cache layer, etc.

This repo is important to not post notifications to the queue that are irrelevant for the consumer.

For implementing the `getSubscribedAccounts` I did a small refactor because is very similar to how we get all pages for the subscriptions 

## Trade producer
Creates some skeleton for the trade producer and inject already some relevant repositories. Follow up PRs will continue its implementation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced trade notification processing with a new notification producer for trade-related events.
  - Added support for managing and caching subscribed accounts to improve notification delivery.

- **Improvements**
  - Enhanced notification filtering to ensure only subscribed accounts receive CMS push notifications.
  - Improved efficiency and reliability of fetching all subscribed accounts with a new pagination helper.

- **Refactor**
  - Streamlined repository and producer integration for better maintainability and extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->