### PR TITLE
Apply automatic migrations

### DIFF
--- a/apps/api/src/app/plugins/orm-analytics.ts
+++ b/apps/api/src/app/plugins/orm-analytics.ts
@@ -11,25 +11,30 @@ export default fp(async function (fastify: FastifyInstance) {
     database: fastify.config.COW_ANALYTICS_DATABASE_NAME,
     username: fastify.config.COW_ANALYTICS_DATABASE_USERNAME,
     password: fastify.config.COW_ANALYTICS_DATABASE_PASSWORD,
-  }
+  };
 
-  const dbParamsAreInvalid = Object.values(dbParams).some((v) => Number.isNaN(v) || v === undefined);
+  const dbParamsAreInvalid = Object.values(dbParams).some(
+    (v) => Number.isNaN(v) || v === undefined
+  );
 
   if (dbParamsAreInvalid) {
-    console.error('Invalid CoW Analytics database parameters, please check COW_ANALYTICS_* env vars');
-    return
+    console.error(
+      'Invalid CoW Analytics database parameters, please check COW_ANALYTICS_* env vars'
+    );
+    return;
   }
 
   fastify.register(typeORMPlugin, {
     ...dbParams,
+    namespace: 'analytics',
     type: 'postgres',
     entities: [PoolInfo],
     ssl: true,
     extra: {
       ssl: {
-        rejectUnauthorized: false
-      }
-    }
+        rejectUnauthorized: false,
+      },
+    },
   });
 
   fastify.ready((err) => {
@@ -37,6 +42,6 @@ export default fp(async function (fastify: FastifyInstance) {
       throw err;
     }
 
-    fastify.orm.runMigrations({ transaction: 'all' });
+    fastify.orm.analytics.runMigrations({ transaction: 'all' });
   });
 });

--- a/apps/api/src/app/plugins/orm-repositories.ts
+++ b/apps/api/src/app/plugins/orm-repositories.ts
@@ -1,0 +1,67 @@
+import 'reflect-metadata';
+import { FastifyInstance } from 'fastify';
+import typeORMPlugin from 'typeorm-fastify-plugin';
+import fp from 'fastify-plugin';
+import { resolve } from 'path';
+import { logger } from '@cowprotocol/shared';
+
+import { getDatabaseParams } from '@cowprotocol/repositories';
+import { readdir } from 'fs/promises';
+
+export default fp(async function (fastify: FastifyInstance) {
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  const migrationsDir = resolve(
+    __dirname,
+    '../../../../../libs/repositories/src/migrations'
+  );
+
+  fastify.register(typeORMPlugin, {
+    ...getDatabaseParams(),
+    namespace: 'repositories',
+    type: 'postgres',
+    migrations: [`${migrationsDir}/*.js`],
+    migrationsTableName: 'migrations_repositories',
+    entities: [],
+    ssl: isProduction,
+    extra: isProduction
+      ? {
+          ssl: {
+            rejectUnauthorized: false,
+          },
+        }
+      : undefined,
+    logging: true, // Enable TypeORM logging
+  });
+  fastify.ready(async (err) => {
+    if (err) {
+      throw err;
+    }
+
+    try {
+      logger.info('Starting migrations...');
+      logger.info('Migrations dir:', migrationsDir);
+      printMigrations(migrationsDir);
+      const result = await fastify.orm.repositories.runMigrations({
+        transaction: 'all',
+      });
+      logger.info(`${result.length} migrations applied`);
+    } catch (error) {
+      logger.error('Migration error:', error);
+      throw error;
+    }
+  });
+});
+
+async function printMigrations(dirPath: string) {
+  try {
+    const files = (await readdir(dirPath)).filter((file) =>
+      file.endsWith('.js')
+    );
+    for (const file of files) {
+      logger.info(`  - ${file}`);
+    }
+  } catch (err) {
+    logger.error('Error reading directory:', err);
+  }
+}

--- a/apps/api/src/app/plugins/orm-repositories.ts
+++ b/apps/api/src/app/plugins/orm-repositories.ts
@@ -41,7 +41,7 @@ export default fp(async function (fastify: FastifyInstance) {
     try {
       logger.info('Starting migrations...');
       logger.info('Migrations dir:', migrationsDir);
-      printMigrations(migrationsDir);
+      await printMigrations(migrationsDir);
       const result = await fastify.orm.repositories.runMigrations({
         transaction: 'all',
       });

--- a/libs/repositories/src/datasources/orm/postgresOrm.ts
+++ b/libs/repositories/src/datasources/orm/postgresOrm.ts
@@ -2,9 +2,8 @@
 import { DataSource } from 'typeorm';
 
 import assert from 'assert';
-import { IndexerState } from '../../database/IndexerState.entity';
 
-export function createNewPostgresOrm(): DataSource {
+export function getDatabaseParams() {
   // Note: not using the `ensureEnvs` util function because it causes issues with the migrations)
   assert(process.env.DATABASE_HOST, 'DATABASE_HOST is not set');
   assert(process.env.DATABASE_PORT, 'DATABASE_PORT is not set');
@@ -12,15 +11,19 @@ export function createNewPostgresOrm(): DataSource {
   assert(process.env.DATABASE_PASSWORD, 'DATABASE_PASSWORD is not set');
   assert(process.env.DATABASE_NAME, 'DATABASE_NAME is not set');
 
-  const dataSource = new DataSource({
-    type: 'postgres',
+  return {
     host: process.env.DATABASE_HOST,
     port: Number(process.env.DATABASE_PORT),
     username: process.env.DATABASE_USERNAME,
     password: process.env.DATABASE_PASSWORD,
     database: process.env.DATABASE_NAME,
-    // entities: ['src/database/*.ts'],
-    entities: [IndexerState],
+  };
+}
+
+export function createNewPostgresOrm(): DataSource {
+  const dataSource = new DataSource({
+    type: 'postgres',
+    ...getDatabaseParams(),
     migrations: ['src/migrations/*.ts'],
     migrationsTableName: 'migrations_repositories',
   });

--- a/libs/repositories/src/datasources/orm/postgresOrm.ts
+++ b/libs/repositories/src/datasources/orm/postgresOrm.ts
@@ -2,6 +2,7 @@
 import { DataSource } from 'typeorm';
 
 import assert from 'assert';
+import { IndexerState } from '../../database/IndexerState.entity';
 
 export function getDatabaseParams() {
   // Note: not using the `ensureEnvs` util function because it causes issues with the migrations)
@@ -24,6 +25,7 @@ export function createNewPostgresOrm(): DataSource {
   const dataSource = new DataSource({
     type: 'postgres',
     ...getDatabaseParams(),
+    entities: [IndexerState],
     migrations: ['src/migrations/*.ts'],
     migrationsTableName: 'migrations_repositories',
   });


### PR DESCRIPTION
Automatically apply the repository migrations.

## background on this PR
I was not planning to do this PR, as I just need to create a single table, and I was fine with applying the migrations to a remote db, but I don't have write permissions to production or staging

There might be many repositories using the DB, and can also be used in different apps. If I try to apply migrations in all apps boot, there could be a race condition. My first approach was using docker and apply the migration when we deploy the services, but later I realised there was a simple way by using the API. 

The API is deployed each time there's a new BFF version, so now in its boot will apply any un-applied migration. 
It was also a bit of not a straight line to make it work. I will try to merge this PR and test this in AWS to see if it works well there. 

# Changes

## Namespaces for different ORM
The API had an orm of `typeorm` 

## Automatically apply migrations of the repositories 
The API defines a new plugin that applies the migrations. 

<img width="698" alt="image" src="https://github.com/user-attachments/assets/88da85b3-421f-4a85-9121-2ee09b920c7e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new plugin to manage PostgreSQL database connections and migrations, with improved logging and error handling.
- **Refactor**
  - Updated database connection logic for improved maintainability and clarity.
  - Repository access for analytics endpoints now uses a dedicated analytics namespace.
- **Chores**
  - Enhanced code formatting for readability across several modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->