### PR TITLE
fix: make Telegram message prettier

### DIFF
--- a/apps/notification-producer/src/producers/trade/fromTradeToNotification.ts
+++ b/apps/notification-producer/src/producers/trade/fromTradeToNotification.ts
@@ -52,13 +52,15 @@ export async function fromTradeToNotification(props: {
   const sellTokenName = formatTokenName(sellToken);
   const buyTokenName = formatTokenName(buyToken);
 
-  const message = `Trade ${sellAmountFormatted} ${sellTokenName} for ${buyAmountFormatted} ${buyTokenName}`;
+  const title = `Trade ${sellAmountFormatted} ${sellTokenName} for ${buyAmountFormatted} ${buyTokenName} in ${ChainNames[chainId]}`;
+  const message = `Account: ${owner}`
+
   const url = orderUid ? getExplorerUrl(chainId, orderUid) : undefined;
   logger.info(`${prefix} New ${message} for ${owner}`);
   return {
     id,
     account: owner,
-    title: `New Trade from ${owner} in ${ChainNames[chainId]}`,
+    title,
     message,
     url,
   };

--- a/apps/telegram/src/main.ts
+++ b/apps/telegram/src/main.ts
@@ -86,7 +86,9 @@ async function sendNotificationToTelegram(
         logger.info(
           `[telegram] Sending message ${id} to chatId ${chatId}. Title: ${title}. Message: ${message}. URL=${url}`
         );
-        telegramBot.sendMessage(chatId, formatMessage(notification));
+        telegramBot.sendMessage(chatId, formatMessage(notification), {
+          disable_web_page_preview: true
+        });
 
         // Acknowledge the message once its been sent to at least one subscriber for this account
         consumeMessage = true;
@@ -144,10 +146,10 @@ async function subscribeToNotifications() {
 }
 
 function formatMessage({ title, message, url }: PushNotification) {
-  const moreInfo = url ? `\n\nMore info in ${url}` : '';
+  const moreInfo = url ? `\n\nMore info in [Explorer](${url})` : '';
 
   return `\
-${title}.
+**${title}**.
 
 ${message}${moreInfo}`;
 }


### PR DESCRIPTION
1. Removed link preview

Changed message to:

**Trade 0.009614511512371566 WETH for 16.862819 USDC in Base.**

Account: 0x79063d9173C09887d536924E2F6eADbaBAc099f5

More info in [Explorer](https://explorer.cow.fi/base/orders/0x34bd97c4eb74e669f180f9fc34e37c528840bc951e0812d181b224f3f9e910d479063d9173c09887d536924e2f6eadbabac099f5680a4211)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Notification titles now display detailed trade information and chain names, while messages are simplified to show only the account owner.
  - Telegram notifications feature improved formatting with bold titles and labeled links, and web page previews are disabled for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->