### PR TITLE
feat: add state diff to tenderly simulate bundle

### DIFF
--- a/apps/api/src/app/routes/__chainId/simulation/simulateBundle.ts
+++ b/apps/api/src/app/routes/__chainId/simulation/simulateBundle.ts
@@ -49,6 +49,11 @@ const successSchema = {
           },
         },
       },
+      stateDiff: {
+        title: 'State Diff',
+        description: 'Changes in blockchain states.',
+        type: 'array',
+      },
       gasUsed: {
         title: 'Gas Used',
         description: 'Amount of gas used in the transaction with decimals.',

--- a/libs/repositories/src/repos/SimulationRepository/SimulationRepository.ts
+++ b/libs/repositories/src/repos/SimulationRepository/SimulationRepository.ts
@@ -1,4 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/shared';
+import { StateDiff } from './tenderlyTypes';
 
 export interface SimulationInput {
   input: string;
@@ -16,6 +17,7 @@ export interface SimulationData {
   // { [address: string]: { [token: string]: balanceDiff: string } }
   // example: { '0x123': { '0x456': '100', '0xabc': '-100' } }
   cumulativeBalancesDiff: Record<string, Record<string, string>>;
+  stateDiff: Omit<StateDiff, 'raw'>[];
   gasUsed?: string;
 }
 

--- a/libs/repositories/src/repos/SimulationRepository/SimulationRepository.ts
+++ b/libs/repositories/src/repos/SimulationRepository/SimulationRepository.ts
@@ -17,7 +17,7 @@ export interface SimulationData {
   // { [address: string]: { [token: string]: balanceDiff: string } }
   // example: { '0x123': { '0x456': '100', '0xabc': '-100' } }
   cumulativeBalancesDiff: Record<string, Record<string, string>>;
-  stateDiff: Omit<StateDiff, 'raw'>[];
+  stateDiff: StateDiff[];
   gasUsed?: string;
 }
 

--- a/libs/repositories/src/repos/SimulationRepository/SimulationrepositoryTenderly.test.ts
+++ b/libs/repositories/src/repos/SimulationRepository/SimulationrepositoryTenderly.test.ts
@@ -7,7 +7,7 @@ import {
   TENDERLY_ORG_NAME,
   TENDERLY_PROJECT_NAME,
 } from '../../datasources/tenderlyApi';
-import { AssetChange } from './tenderlyTypes';
+import { AssetChange, StateDiff } from './tenderlyTypes';
 
 // Transfering ETH from WETH to NULL ADDRESS
 const TENDERLY_SIMULATION = {
@@ -261,6 +261,509 @@ describe('SimulationRepositoryTenderly', () => {
       ];
 
       expect(tenderlyRepository.buildBalancesDiff(input)).toEqual(expected);
+    });
+  });
+  describe('buildStateDiff', () => {
+    it('should correctly process a single state diff', () => {
+      const input: StateDiff[][] = [
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: {
+              '0xabc': '1000',
+              '0xdef': '2000',
+            },
+            dirty: {
+              '0xabc': '1500',
+              '0xdef': '1500',
+            },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x1000',
+                dirty: '0x1500',
+              },
+              {
+                address: '0x123',
+                key: '0xkey2',
+                original: '0x2000',
+                dirty: '0x1500',
+              },
+            ],
+          },
+        ],
+      ];
+
+      const expected: StateDiff[][] = [
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: {
+              '0xabc': '1000',
+              '0xdef': '2000',
+            },
+            dirty: {
+              '0xabc': '1500',
+              '0xdef': '1500',
+            },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x1000',
+                dirty: '0x1500',
+              },
+              {
+                address: '0x123',
+                key: '0xkey2',
+                original: '0x2000',
+                dirty: '0x1500',
+              },
+            ],
+          },
+        ],
+      ];
+
+      expect(tenderlyRepository.buildStateDiff(input)).toEqual(expected);
+    });
+
+    it('should accumulate state changes across multiple simulations', () => {
+      const input: StateDiff[][] = [
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: {
+              '0xabc': '1000',
+              '0xdef': '2000',
+            },
+            dirty: {
+              '0xabc': '1500',
+              '0xdef': '1500',
+            },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x1000',
+                dirty: '0x1500',
+              },
+              {
+                address: '0x123',
+                key: '0xkey2',
+                original: '0x2000',
+                dirty: '0x1500',
+              },
+            ],
+          },
+        ],
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: {
+              '0xabc': '1500',
+              '0xdef': '1500',
+            },
+            dirty: {
+              '0xabc': '2000',
+              '0xdef': '1000',
+            },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x1500',
+                dirty: '0x2000',
+              },
+              {
+                address: '0x123',
+                key: '0xkey2',
+                original: '0x1500',
+                dirty: '0x1000',
+              },
+            ],
+          },
+        ],
+      ];
+
+      const expected: StateDiff[][] = [
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: {
+              '0xabc': '1000',
+              '0xdef': '2000',
+            },
+            dirty: {
+              '0xabc': '1500',
+              '0xdef': '1500',
+            },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x1000',
+                dirty: '0x1500',
+              },
+              {
+                address: '0x123',
+                key: '0xkey2',
+                original: '0x2000',
+                dirty: '0x1500',
+              },
+            ],
+          },
+        ],
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: {
+              '0xabc': '1000',
+              '0xdef': '2000',
+            },
+            dirty: {
+              '0xabc': '2000',
+              '0xdef': '1000',
+            },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x1000',
+                dirty: '0x2000',
+              },
+              {
+                address: '0x123',
+                key: '0xkey2',
+                original: '0x2000',
+                dirty: '0x1000',
+              },
+            ],
+          },
+        ],
+      ];
+
+      expect(tenderlyRepository.buildStateDiff(input)).toEqual(expected);
+    });
+
+    it('should process multiple addresses with different properties', () => {
+      const input: StateDiff[][] = [
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: { '0xabc': '100' },
+            dirty: { '0xabc': '200' },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x100',
+                dirty: '0x200',
+              },
+            ],
+          },
+          {
+            address: '0x456',
+            soltype: {
+              name: 'allowed',
+              type: 'mapping (address => mapping (address => uint256))',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x001',
+              indexed: false,
+            },
+            original: { '0xabc': { '0xdef': '1000' } },
+            dirty: { '0xabc': { '0xdef': '500' } },
+            raw: [
+              {
+                address: '0x456',
+                key: '0xkey2',
+                original: '0x1000',
+                dirty: '0x500',
+              },
+            ],
+          },
+        ],
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: { '0xabc': '200' },
+            dirty: { '0xabc': '300' },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x200',
+                dirty: '0x300',
+              },
+            ],
+          },
+        ],
+      ];
+
+      const expected: StateDiff[][] = [
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: { '0xabc': '100' },
+            dirty: { '0xabc': '200' },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x100',
+                dirty: '0x200',
+              },
+            ],
+          },
+          {
+            address: '0x456',
+            soltype: {
+              name: 'allowed',
+              type: 'mapping (address => mapping (address => uint256))',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x001',
+              indexed: false,
+            },
+            original: { '0xabc': { '0xdef': '1000' } },
+            dirty: { '0xabc': { '0xdef': '500' } },
+            raw: [
+              {
+                address: '0x456',
+                key: '0xkey2',
+                original: '0x1000',
+                dirty: '0x500',
+              },
+            ],
+          },
+        ],
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: { '0xabc': '100' },
+            dirty: { '0xabc': '300' },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x100',
+                dirty: '0x300',
+              },
+            ],
+          },
+          {
+            address: '0x456',
+            soltype: {
+              name: 'allowed',
+              type: 'mapping (address => mapping (address => uint256))',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x001',
+              indexed: false,
+            },
+            original: { '0xabc': { '0xdef': '1000' } },
+            dirty: { '0xabc': { '0xdef': '500' } },
+            raw: [
+              {
+                address: '0x456',
+                key: '0xkey2',
+                original: '0x1000',
+                dirty: '0x500',
+              },
+            ],
+          },
+        ],
+      ];
+
+      expect(tenderlyRepository.buildStateDiff(input)).toEqual(expected);
+    });
+
+    it('should handle empty input', () => {
+      const input: StateDiff[][] = [];
+      expect(tenderlyRepository.buildStateDiff(input)).toEqual([]);
+    });
+
+    it('should handle input with empty state diffs', () => {
+      const input: StateDiff[][] = [[], []];
+      expect(tenderlyRepository.buildStateDiff(input)).toEqual([[], []]);
+    });
+
+    it('should correctly update raw elements when address and key match', () => {
+      const input: StateDiff[][] = [
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: { '0xabc': '100' },
+            dirty: { '0xabc': '200' },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x0064', // hex for 100
+                dirty: '0x00c8', // hex for 200
+              },
+            ],
+          },
+        ],
+        [
+          {
+            address: '0x123',
+            soltype: null,
+            original: null,
+            dirty: null,
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x00c8', // hex for 200
+                dirty: '0x012c', // hex for 300
+              },
+            ],
+          },
+        ],
+      ];
+
+      // In the expected result, the accumulated state should maintain the original "original" value
+      // but update the "dirty" value
+      const expected: StateDiff[][] = [
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: { '0xabc': '100' },
+            dirty: { '0xabc': '200' },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x0064',
+                dirty: '0x00c8',
+              },
+            ],
+          },
+        ],
+        [
+          {
+            address: '0x123',
+            soltype: {
+              name: 'balanceOf',
+              type: 'mapping (address => uint256)',
+              storage_location: 'storage',
+              offset: 0,
+              index: '0x000',
+              indexed: false,
+            },
+            original: { '0xabc': '100' },
+            dirty: { '0xabc': '200' },
+            raw: [
+              {
+                address: '0x123',
+                key: '0xkey1',
+                original: '0x0064', // keeps the original original
+                dirty: '0x012c', // updated with the latest dirty value
+              },
+            ],
+          },
+        ],
+      ];
+
+      expect(tenderlyRepository.buildStateDiff(input)).toEqual(expected);
     });
   });
 });

--- a/libs/repositories/src/repos/SimulationRepository/tenderlyTypes.ts
+++ b/libs/repositories/src/repos/SimulationRepository/tenderlyTypes.ts
@@ -588,7 +588,7 @@ export interface StateDiff {
   raw: RawElement[];
 }
 
-interface RawElement {
+export interface RawElement {
   address: string;
   key: string;
   original: string;

--- a/libs/repositories/src/repos/SimulationRepository/tenderlyTypes.ts
+++ b/libs/repositories/src/repos/SimulationRepository/tenderlyTypes.ts
@@ -115,7 +115,7 @@ interface SoltypeElement {
   name: string;
   type: SoltypeType;
   storage_location: StorageLocation;
-  components: SoltypeElement[] | null;
+  components?: SoltypeElement[] | null;
   offset: number;
   index: string;
   indexed: boolean;
@@ -135,35 +135,30 @@ enum SimpleTypeType {
   Uint = 'uint',
 }
 
-enum StorageLocation {
-  Calldata = 'calldata',
-  Default = 'default',
-  Memory = 'memory',
-  Storage = 'storage',
-}
+type StorageLocation = 'calldata' | 'default' | 'memory' | 'storage';
 
-enum SoltypeType {
-  Address = 'address',
-  Bool = 'bool',
-  Bytes32 = 'bytes32',
-  MappingAddressUint256 = 'mapping (address => uint256)',
-  MappingUint256Uint256 = 'mapping (uint256 => uint256)',
-  String = 'string',
-  Tuple = 'tuple',
-  TypeAddress = 'address[]',
-  TypeTuple = 'tuple[]',
-  Uint16 = 'uint16',
-  Uint256 = 'uint256',
-  Uint48 = 'uint48',
-  Uint56 = 'uint56',
-  Uint8 = 'uint8',
-}
+type SoltypeType =
+  | 'address'
+  | 'bool'
+  | 'bytes32'
+  | 'mapping (address => uint256)'
+  | 'mapping (uint256 => uint256)'
+  | 'mapping (address => mapping (address => uint256))'
+  | 'string'
+  | 'tuple'
+  | 'address[]'
+  | 'tuple[]'
+  | 'uint16'
+  | 'uint256'
+  | 'uint48'
+  | 'uint56'
+  | 'uint8';
 
 interface Output {
   name: string;
   type: SoltypeType;
   storage_location: StorageLocation;
-  components: SoltypeElement[] | null;
+  components?: SoltypeElement[] | null;
   offset: number;
   index: string;
   indexed: boolean;
@@ -551,7 +546,7 @@ interface PurpleSoltype {
   name: string;
   type: SoltypeType;
   storage_location: StorageLocation;
-  components: null;
+  components?: null;
   offset: number;
   index: string;
   indexed: boolean;
@@ -583,8 +578,8 @@ interface LogRaw {
 export interface StateDiff {
   address: string;
   soltype: SoltypeElement | null;
-  original: string | Record<string, any>;
-  dirty: string | Record<string, any>;
+  original: string | Record<string, any> | null;
+  dirty: string | Record<string, any> | null;
   raw: RawElement[];
 }
 

--- a/libs/repositories/src/repos/SimulationRepository/tenderlyTypes.ts
+++ b/libs/repositories/src/repos/SimulationRepository/tenderlyTypes.ts
@@ -580,7 +580,8 @@ interface LogRaw {
   data: string;
 }
 
-interface StateDiff {
+export interface StateDiff {
+  address: string;
   soltype: SoltypeElement | null;
   original: string | Record<string, any>;
   dirty: string | Record<string, any>;


### PR DESCRIPTION
## Context
Some hooks on cowswap need state_diff data to display correct informations to the user.

For example, In Morpho contracts, the user position is stored as a state in the blockchain, not being a ERC20 balance. This way, only balancesDiff does not provide information about other hooks changes and will lead to incorrect user position display if more than one hook is added.

## Included in this PR

- Enhance SimulationRepositoryTenderly with a buildStateDiff function to process stateDiff
- Add stateDiff to simulateBundle response
- Enhance SimulationRepositoryTenderly tests to cover tests on buildStateDiff method