### PR TITLE
feat: change Avalanche explorer from Snowtrace to Snowscan

### DIFF
--- a/libs/repositories/src/const.ts
+++ b/libs/repositories/src/const.ts
@@ -29,7 +29,7 @@ export const USDC: Record<SupportedChainId, TokenAddressAndDecimals> = {
     decimals: 6,
   },
   [SupportedChainId.AVALANCHE]: {
-    // https://snowtrace.io/token/0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e
+    // https://snowscan.xyz/token/0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e
     address: '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
     decimals: 6,
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "private": true,
   "dependencies": {
     "@cowprotocol/cms": "^0.3.0-RC.4",
-    "@cowprotocol/cow-sdk": "6.0.0-RC.59",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.63",
     "@fastify/autoload": "~5.7.1",
     "@fastify/caching": "^8.3.0",
     "@fastify/cors": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,10 +1117,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.8.0.tgz#daffbd9846231c11a74b15a186bb754627e420b0"
   integrity sha512-rMEHo1UBB6k4kRoWejHZNGggg6IBVt7vAd8x0FhEvjxhbq3zlAex61f9HpAcDExJNuvfwwDjsOc/7UGztCzhSw==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.59":
-  version "6.0.0-RC.59"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.59.tgz#6981c912fff982b30b3a015df4bed3127dd59186"
-  integrity sha512-VqqtyxzfAw4jzltNXz0/1fU1rgHBRi3XQAIXcaisdZRipsVeM8G1Mt3T+TvXvUGT4lB3Dn9nU3EYyXXlC1aXXA==
+"@cowprotocol/cow-sdk@6.0.0-RC.63":
+  version "6.0.0-RC.63"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.63.tgz#b031051d6d85f35446bea094c7df7870eb7729b9"
+  integrity sha512-3oKP2fvW08eoVT3SIp2ghESLitPpmJP5xdoMRhIsO98Z54vjJ/WidGQN3YRQZuPRXF61LwJ+gFKZPtOBtF7I1g==
   dependencies:
     "@cowprotocol/app-data" "^3.1.0"
     "@cowprotocol/contracts" "^1.8.0"
@@ -1129,7 +1129,6 @@
     "@weiroll/weiroll.js" "^0.3.0"
     cross-fetch "^3.2.0"
     deepmerge "^4.3.1"
-    ethers "^5.8.0"
     exponential-backoff "^3.1.2"
     graphql "^16.11.0"
     graphql-request "^4.3.0"
@@ -5453,7 +5452,7 @@ ethereum-cryptography@^3.0.0:
     "@scure/bip32" "1.7.0"
     "@scure/bip39" "1.6.0"
 
-ethers@^5.3.1, ethers@^5.8.0:
+ethers@^5.3.1:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.8.0.tgz#97858dc4d4c74afce83ea7562fe9493cedb4d377"
   integrity sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==


### PR DESCRIPTION
# Summary

- Change Avalanche explorer from SnowTrace to [SnowScan](https://snowscan.xyz)
- update `cow-sdk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the reference URL for the Avalanche chain's USDC token to a new explorer.
  - Upgraded the dependency version of `@cowprotocol/cow-sdk` to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->