### PR TITLE
fix: add multicall3 to lens from CoW SDK

### DIFF
--- a/libs/repositories/src/datasources/viem.ts
+++ b/libs/repositories/src/datasources/viem.ts
@@ -1,6 +1,6 @@
-import { SupportedChainId } from '@cowprotocol/cow-sdk';
+import { SupportedChainId, lens as lensCoWSdk } from '@cowprotocol/cow-sdk';
 import { AllChainIds, logger } from '@cowprotocol/shared';
-import { Chain, createPublicClient, http, PublicClient, webSocket } from 'viem';
+import { Chain, ChainContract, createPublicClient, http, PublicClient, webSocket } from 'viem';
 import {
   arbitrum,
   avalanche,
@@ -20,7 +20,13 @@ const NETWORKS: Record<SupportedChainId, Chain> = {
   [SupportedChainId.BASE]: base,
   [SupportedChainId.POLYGON]: polygon,
   [SupportedChainId.AVALANCHE]: avalanche,
-  [SupportedChainId.LENS]: lens,
+  [SupportedChainId.LENS]: {
+    ...lens,
+    contracts: {
+      ...lens.contracts,
+      multicall3: lensCoWSdk.contracts.multicall3 as ChainContract,
+    },
+  },
   [SupportedChainId.BNB]: bsc,
   [SupportedChainId.SEPOLIA]: sepolia,
 };


### PR DESCRIPTION
`multicall3` contract is not specified for Lens in Viem library.
Ideally, it should be fixed in viem, but as a temporary solution I added the contract from cow-sdk.

<img width="770" height="446" alt="image" src="https://github.com/user-attachments/assets/67e19773-4b73-40ed-9407-fca4ba15e2db" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Lens network configuration to use the official multicall contract from our SDK, improving compatibility and reducing failures in batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->