### PR TITLE
fix: map eth-flow order sell token

### DIFF
--- a/apps/notification-producer/src/producers/trade/fromTradeToNotification.ts
+++ b/apps/notification-producer/src/producers/trade/fromTradeToNotification.ts
@@ -1,4 +1,4 @@
-import { SupportedChainId } from '@cowprotocol/cow-sdk';
+import { ALL_SUPPORTED_CHAINS_MAP, SupportedChainId } from '@cowprotocol/cow-sdk';
 import { PushNotification } from '@cowprotocol/notifications';
 import { Erc20Repository } from '@cowprotocol/repositories';
 import { getAddress } from 'viem';
@@ -13,6 +13,7 @@ import {
 export async function fromTradeToNotification(props: {
   prefix: string;
   id: string;
+  isEthFlowOrder: boolean;
   chainId: SupportedChainId;
   orderUid: string;
   owner: string;
@@ -29,6 +30,7 @@ export async function fromTradeToNotification(props: {
     id,
     chainId,
     owner,
+    isEthFlowOrder,
     sellTokenAddress,
     buyTokenAddress,
     sellAmount,
@@ -37,13 +39,15 @@ export async function fromTradeToNotification(props: {
     prefix,
     orderUid,
     transactionHash,
-    logIndex,
+    logIndex
   } = props;
 
-  const sellToken = await erc20Repository.get(
-    chainId,
-    getAddress(sellTokenAddress)
-  );
+  const sellToken = isEthFlowOrder
+    ? ALL_SUPPORTED_CHAINS_MAP[chainId].nativeCurrency
+    : await erc20Repository.get(
+      chainId,
+      getAddress(sellTokenAddress)
+    );
 
   const buyToken = await erc20Repository.get(
     chainId,

--- a/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
+++ b/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
@@ -115,6 +115,7 @@ export async function getTradeNotifications(
             acc.push(
               fromTradeToNotification({
                 prefix,
+                isEthFlowOrder,
                 id: 'Trade-' + log.transactionHash + '-' + log.logIndex,
                 chainId,
                 orderUid,


### PR DESCRIPTION
Use native token symbol in notification template message instead of wrapped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Trade notifications now support Eth Flow orders, automatically displaying the chain’s native currency as the sell token when applicable for clearer, more accurate messaging.
  - Improved token resolution logic enhances reliability of notifications across supported networks, with no changes required from users and no impact on non-Eth Flow orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->