### PR TITLE
feat(notifications): add expired orders notifications

### DIFF
--- a/apps/notification-producer/src/main.ts
+++ b/apps/notification-producer/src/main.ts
@@ -6,11 +6,15 @@ import {
   getErc20Repository,
   getIndexerStateRepository,
   getPushNotificationsRepository,
-  getPushSubscriptionsRepository
+  getPushSubscriptionsRepository,
+  getExpiredOrdersRepository
 } from '@cowprotocol/services';
 
 import { Runnable } from '../types';
 import { TradeNotificationProducer } from './producers/trade/TradeNotificationProducer';
+import {
+  ExpiredOrdersNotificationProducer
+} from './producers/expired-orders/ExpiredOrdersNotificationProducer';
 import { ALL_SUPPORTED_CHAIN_IDS } from '@cowprotocol/cow-sdk';
 import ms from 'ms';
 import { CmsNotificationProducer } from './producers/cms/CmsNotificationProducer';
@@ -36,6 +40,7 @@ async function mainLoop() {
   const pushSubscriptionsRepository = getPushSubscriptionsRepository();
   const indexerStateRepository = getIndexerStateRepository();
   const onChainPlacedOrdersRepository = getOnChainPlacedOrdersRepository();
+  const expiredOrdersRepository = getExpiredOrdersRepository();
 
   const repositories = {
     pushNotificationsRepository,
@@ -55,6 +60,15 @@ async function mainLoop() {
       return new TradeNotificationProducer({
         ...repositories,
         chainId,
+      });
+    }),
+
+    // Expired order producer
+    ...chainIds.map((chainId) => {
+      return new ExpiredOrdersNotificationProducer({
+        chainId,
+        ...repositories,
+        expiredOrdersRepository
       });
     }),
   ];

--- a/apps/notification-producer/src/producers/expired-orders/ExpiredOrdersNotificationProducer.ts
+++ b/apps/notification-producer/src/producers/expired-orders/ExpiredOrdersNotificationProducer.ts
@@ -1,0 +1,148 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk';
+import {
+  Erc20Repository,
+  ExpiredOrdersRepository,
+  IndexerStateRepository,
+  IndexerStateValue,
+  OnChainPlacedOrdersRepository,
+  PushNotificationsRepository,
+  PushSubscriptionsRepository
+} from '@cowprotocol/repositories';
+
+import { Runnable } from '../../../types';
+import { doForever, logger } from '@cowprotocol/shared';
+import { getExpiredOrderNotification } from './getExpiredOrderNotification';
+
+async function wait(time: number) {
+  return new Promise((res) => setTimeout(res, time))
+}
+
+const WAIT_TIME = 10_000;
+const POLLING_INTERVAL = 14_000;
+const PRODUCER_NAME = 'expired_orders_notification_producer';
+
+export type ExpiredOrdersNotificationProducerProps = {
+  chainId: SupportedChainId;
+  erc20Repository: Erc20Repository;
+  indexerStateRepository: IndexerStateRepository;
+  pushSubscriptionsRepository: PushSubscriptionsRepository;
+  expiredOrdersRepository: ExpiredOrdersRepository;
+  pushNotificationsRepository: PushNotificationsRepository;
+  onChainPlacedOrdersRepository: OnChainPlacedOrdersRepository;
+};
+
+export interface ExpiredOrdersNotificationProducerState extends IndexerStateValue {
+  lastCheckTimestamp: string;
+}
+
+export class ExpiredOrdersNotificationProducer implements Runnable {
+  isStopping = false;
+  prefix: string;
+
+  constructor(private props: ExpiredOrdersNotificationProducerProps) {
+    this.prefix = '[ExpiredOrdersNotificationProducer:' + this.props.chainId + ']';
+  }
+
+  /**
+   * Main loop: Run the CMS notification producer. This method runs indefinitely,
+   * fetching notifications and sending them to the queue.
+   *
+   * The method should not throw or finish.
+   */
+  async start(): Promise<void> {
+    await doForever({
+      name: 'ExpiredOrdersNotificationProducer:' + this.props.chainId,
+      callback: async (stop) => {
+        if (this.isStopping) {
+          stop();
+          return;
+        }
+        await this.processExpiredOrders();
+      },
+      waitTimeMilliseconds: WAIT_TIME,
+      logger
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.isStopping = true;
+  }
+
+  async processExpiredOrders(): Promise<void> {
+    return this.pollExpiredOrders().then(() => {
+      return wait(POLLING_INTERVAL);
+    }).then(() => {
+      if (this.isStopping) return
+
+      return this.processExpiredOrders();
+    });
+  }
+
+  async pollExpiredOrders() {
+    const {
+      chainId,
+      erc20Repository,
+      indexerStateRepository,
+      pushSubscriptionsRepository,
+      expiredOrdersRepository,
+      pushNotificationsRepository
+    } = this.props;
+
+    const nowTimestamp = Math.ceil(Date.now() / 1000);
+
+    const stateRegistry =
+      await indexerStateRepository.get<ExpiredOrdersNotificationProducerState>(
+        PRODUCER_NAME,
+        chainId
+      );
+
+    const lastCheckTimestampRaw = stateRegistry?.state.lastCheckTimestamp;
+
+    if (lastCheckTimestampRaw) {
+      const lastCheckTimestamp = Number(lastCheckTimestampRaw);
+
+      // TODO: support ethFlowAddresses as well
+      const accounts =
+        await pushSubscriptionsRepository.getAllSubscribedAccounts();
+
+      const expiredOrders = await expiredOrdersRepository.fetchExpiredOrdersForAccounts({
+        chainId,
+        accounts,
+        lastCheckTimestamp,
+        nowTimestamp
+      });
+
+      logger.debug(
+        `${this.prefix} got ${expiredOrders.length} expired orders of ${accounts.length} accounts, lastCheckTimestamp=${lastCheckTimestamp}`
+      );
+
+      const notifications = await Promise.all(expiredOrders.map(order => {
+        return getExpiredOrderNotification(order, {
+          chainId,
+          nowTimestamp,
+          lastCheckTimestamp,
+          isEthFlowOrder: false, // TODO: add eth-flow orders support
+          owner: order.owner, // TODO: add eth-flow orders support
+          erc20Repository
+        });
+      }));
+
+      // Return early if there are no notifications
+      if (notifications.length > 0) {
+        logger.info(
+          `${this.prefix} Sending ${notifications.length} notifications`,
+          JSON.stringify(notifications, null, 2)
+        );
+
+        // Post notifications to queue
+        pushNotificationsRepository.send(notifications);
+      }
+    }
+
+    await indexerStateRepository.upsert<ExpiredOrdersNotificationProducerState>(
+      PRODUCER_NAME,
+      { lastCheckTimestamp: nowTimestamp.toString() },
+      chainId
+    );
+  }
+}

--- a/apps/notification-producer/src/producers/expired-orders/getExpiredOrderNotification.ts
+++ b/apps/notification-producer/src/producers/expired-orders/getExpiredOrderNotification.ts
@@ -1,0 +1,51 @@
+import { PushNotification } from '@cowprotocol/notifications';
+import { Erc20Repository, ParsedExpiredOrder } from '@cowprotocol/repositories';
+import { getExplorerUrl } from '@cowprotocol/shared';
+import { type SupportedChainId } from '@cowprotocol/cow-sdk';
+import { getNotificationSummary } from '../../utils/getNotificationSummary';
+
+export interface ExpiredOrderNotificationContext {
+  chainId: SupportedChainId;
+  nowTimestamp: number;
+  lastCheckTimestamp: number;
+  isEthFlowOrder: boolean;
+  owner: string;
+  erc20Repository: Erc20Repository;
+}
+
+export async function getExpiredOrderNotification(
+  expiredOrder: ParsedExpiredOrder,
+  notificationContext: ExpiredOrderNotificationContext
+): Promise<PushNotification> {
+  const { chainId, lastCheckTimestamp, nowTimestamp, isEthFlowOrder, owner, erc20Repository } = notificationContext;
+
+  const summary = await getNotificationSummary({
+    chainId,
+    isEthFlowOrder,
+    erc20Repository,
+    sellAmount: expiredOrder.sellAmount,
+    buyAmount: expiredOrder.buyAmount,
+    sellTokenAddress: expiredOrder.sellTokenAddress,
+    buyTokenAddress: expiredOrder.buyTokenAddress
+  });
+
+  const title = `🕐 Order ${summary} has expired`;
+  const message = `
+  Expiration time: ${new Date(expiredOrder.validTo * 1000).toISOString()}.
+  Account: ${owner}.
+  `.trim();
+
+  const url = getExplorerUrl(chainId, expiredOrder.uid);
+
+  return {
+    id: 'OrderExpired-' + expiredOrder.validTo + '-' + lastCheckTimestamp,
+    account: expiredOrder.owner.toLowerCase(),
+    title,
+    message,
+    url,
+    context: {
+      chainId: chainId.toString(),
+      nowTimestamp: nowTimestamp.toString()
+    }
+  };
+}

--- a/apps/notification-producer/src/producers/trade/TradeNotificationProducer.ts
+++ b/apps/notification-producer/src/producers/trade/TradeNotificationProducer.ts
@@ -204,10 +204,10 @@ export class TradeNotificationProducer implements Runnable {
         `${this.prefix} Sending ${notifications.length} notifications`,
         JSON.stringify(notifications, null, 2)
       );
-    }
 
-    // Post notifications to queue
-    this.props.pushNotificationsRepository.send(notifications);
+      // Post notifications to queue
+      this.props.pushNotificationsRepository.send(notifications);
+    }
 
     // Update state
     await indexerStateRepository.upsert<TradeNotificationProducerState>(

--- a/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
+++ b/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
@@ -109,7 +109,7 @@ export async function getTradeNotifications(
 
               return orderUids.includes(orderUid.toLowerCase());
             })
-            : owner;
+            : owner.toLowerCase();
 
           if (orderOwner) {
             acc.push(
@@ -119,7 +119,7 @@ export async function getTradeNotifications(
                 id: 'Trade-' + log.transactionHash + '-' + log.logIndex,
                 chainId,
                 orderUid,
-                owner: getAddress(orderOwner),
+                owner: orderOwner,
                 sellTokenAddress,
                 buyTokenAddress,
                 sellAmount,

--- a/apps/notification-producer/src/utils/getNotificationSummary.ts
+++ b/apps/notification-producer/src/utils/getNotificationSummary.ts
@@ -1,0 +1,38 @@
+import { ALL_SUPPORTED_CHAINS_MAP, SupportedChainId } from '@cowprotocol/cow-sdk';
+import { getAddress } from 'viem';
+import { ChainNames, formatAmount, formatTokenName } from '@cowprotocol/shared';
+import { Erc20Repository } from '@cowprotocol/repositories';
+
+interface OrderInfoForNotificationParams {
+  chainId: SupportedChainId;
+  isEthFlowOrder: boolean;
+  erc20Repository: Erc20Repository;
+  sellTokenAddress: string;
+  buyTokenAddress: string;
+  sellAmount: string | bigint;
+  buyAmount: string | bigint;
+}
+
+export async function getNotificationSummary(params: OrderInfoForNotificationParams): Promise<string> {
+  const { chainId, isEthFlowOrder, erc20Repository } = params;
+
+  const sellToken = isEthFlowOrder
+    ? ALL_SUPPORTED_CHAINS_MAP[chainId].nativeCurrency
+    : await erc20Repository.get(
+      chainId,
+      getAddress(params.sellTokenAddress)
+    );
+
+  const buyToken = await erc20Repository.get(
+    chainId,
+    getAddress(params.buyTokenAddress)
+  );
+
+  const sellAmountFormatted = formatAmount(BigInt(params.sellAmount), sellToken?.decimals);
+  const buyAmountFormatted = formatAmount(BigInt(params.buyAmount), buyToken?.decimals);
+
+  const sellTokenName = formatTokenName(sellToken);
+  const buyTokenName = formatTokenName(buyToken);
+
+  return `${sellAmountFormatted} ${sellTokenName} for ${buyAmountFormatted} ${buyTokenName} in ${ChainNames[chainId]}`
+}

--- a/libs/repositories/src/index.ts
+++ b/libs/repositories/src/index.ts
@@ -57,6 +57,10 @@ export * from './repos/IndexerStateRepository/IndexerStateRepositoryPostgres';
 export * from './repos/OnchainPlacedOrdersRepository/OnChainPlacedOrdersRepository';
 export * from './repos/OnchainPlacedOrdersRepository/OnChainPlacedOrdersRepositoryPostgres';
 
+// ExpiredOrdersRepository
+export * from './repos/ExpiredOrdersRepository/ExpiredOrdersRepository';
+export * from './repos/ExpiredOrdersRepository/ExpiredOrdersRepositoryPostgres';
+
 // Notifications repositories
 export * from './repos/PushNotificationsRepository/PushNotificationsRepository';
 export * from './repos/PushSubscriptionsRepository/PushSubscriptionsRepository';

--- a/libs/repositories/src/repos/ExpiredOrdersRepository/ExpiredOrdersRepository.ts
+++ b/libs/repositories/src/repos/ExpiredOrdersRepository/ExpiredOrdersRepository.ts
@@ -1,0 +1,32 @@
+import type { SupportedChainId } from '@cowprotocol/cow-sdk';
+
+export interface ExpiredOrdersContext {
+  chainId: SupportedChainId
+  accounts: string[]
+  nowTimestamp: number
+  lastCheckTimestamp: number
+}
+
+export interface ExpiredOrder<T = Buffer> {
+  uid: T;
+  owner: T;
+  valid_to: number;
+  sell_token: T;
+  buy_token: T;
+  sell_amount: string;
+  buy_amount: string;
+}
+
+export interface ParsedExpiredOrder {
+  uid: string
+  owner: string
+  validTo: number
+  sellTokenAddress: string
+  buyTokenAddress: string
+  sellAmount: string
+  buyAmount: string
+}
+
+export interface ExpiredOrdersRepository {
+  fetchExpiredOrdersForAccounts(context: ExpiredOrdersContext): Promise<ParsedExpiredOrder[]>
+}

--- a/libs/repositories/src/repos/ExpiredOrdersRepository/ExpiredOrdersRepository.ts
+++ b/libs/repositories/src/repos/ExpiredOrdersRepository/ExpiredOrdersRepository.ts
@@ -1,10 +1,10 @@
 import type { SupportedChainId } from '@cowprotocol/cow-sdk';
 
 export interface ExpiredOrdersContext {
-  chainId: SupportedChainId
-  accounts: string[]
-  nowTimestamp: number
-  lastCheckTimestamp: number
+  chainId: SupportedChainId;
+  accounts: string[];
+  nowTimestamp: number;
+  lastCheckTimestamp: number;
 }
 
 export interface ExpiredOrder<T = Buffer> {
@@ -15,18 +15,20 @@ export interface ExpiredOrder<T = Buffer> {
   buy_token: T;
   sell_amount: string;
   buy_amount: string;
+  kind: 'sell' | 'buy';
 }
 
 export interface ParsedExpiredOrder {
-  uid: string
-  owner: string
-  validTo: number
-  sellTokenAddress: string
-  buyTokenAddress: string
-  sellAmount: string
-  buyAmount: string
+  uid: string;
+  owner: string;
+  validTo: number;
+  sellTokenAddress: string;
+  buyTokenAddress: string;
+  sellAmount: string;
+  buyAmount: string;
+  kind: 'sell' | 'buy';
 }
 
 export interface ExpiredOrdersRepository {
-  fetchExpiredOrdersForAccounts(context: ExpiredOrdersContext): Promise<ParsedExpiredOrder[]>
+  fetchExpiredOrdersForAccounts(context: ExpiredOrdersContext): Promise<ParsedExpiredOrder[]>;
 }

--- a/libs/repositories/src/repos/ExpiredOrdersRepository/ExpiredOrdersRepositoryPostgres.ts
+++ b/libs/repositories/src/repos/ExpiredOrdersRepository/ExpiredOrdersRepositoryPostgres.ts
@@ -1,0 +1,54 @@
+import { Pool, QueryResult } from 'pg';
+import {
+  ExpiredOrder,
+  ExpiredOrdersContext,
+  ExpiredOrdersRepository,
+  ParsedExpiredOrder
+} from './ExpiredOrdersRepository';
+import { getOrderBookDbPool } from '../../datasources/orderBookDbPool';
+import { bytesToHexString } from '../../utils/bytesUtils';
+import { parseExpiredOrder } from './expiredOrdersUtils';
+
+export class ExpiredOrdersRepositoryPostgres implements ExpiredOrdersRepository {
+  async fetchExpiredOrdersForAccounts(context: ExpiredOrdersContext): Promise<ParsedExpiredOrder[]> {
+    const { chainId, accounts } = context;
+
+    const prodDb = getOrderBookDbPool('prod', chainId);
+    const barnDb = getOrderBookDbPool('barn', chainId);
+
+    const prodExpiredOrdersResult = await this.fetchExpiredOrdersFromDb(context, prodDb);
+    const barnExpiredOrdersResult = await this.fetchExpiredOrdersFromDb(context, barnDb);
+
+    const allExpiredOrders = [...(prodExpiredOrdersResult?.rows || []), ...(barnExpiredOrdersResult?.rows || [])];
+
+    const accountsMap = accounts.reduce<Record<string, 1 | undefined>>((acc, account) => {
+      acc[account.toLowerCase()] = 1;
+      return acc
+    }, {})
+
+    return allExpiredOrders.reduce<ParsedExpiredOrder[]>((acc, order) => {
+      if (accountsMap[bytesToHexString(order.owner).toLowerCase()]) {
+        acc.push(parseExpiredOrder(order))
+      }
+
+      return acc
+    }, [])
+  }
+
+  private async fetchExpiredOrdersFromDb(context: ExpiredOrdersContext, db: Pool): Promise<QueryResult<ExpiredOrder> | null> {
+    const { accounts, lastCheckTimestamp, nowTimestamp } = context;
+
+    if (accounts.length === 0) return null;
+
+    const query = `
+        SELECT uid, owner, valid_to, sell_token, buy_token, sell_amount, buy_amount
+        FROM orders
+        WHERE valid_to > ${lastCheckTimestamp}
+          AND valid_to <= ${nowTimestamp}
+        ORDER BY valid_to ASC
+        LIMIT 1000
+    `;
+
+    return db.query(query);
+  }
+}

--- a/libs/repositories/src/repos/ExpiredOrdersRepository/expiredOrdersUtils.ts
+++ b/libs/repositories/src/repos/ExpiredOrdersRepository/expiredOrdersUtils.ts
@@ -1,0 +1,14 @@
+import { ExpiredOrder, ParsedExpiredOrder } from './ExpiredOrdersRepository';
+import { bytesToHexString } from '../../utils/bytesUtils';
+
+export function parseExpiredOrder(order: ExpiredOrder): ParsedExpiredOrder {
+  return {
+    uid: bytesToHexString(order.uid),
+    validTo: order.valid_to,
+    owner: bytesToHexString(order.owner),
+    sellTokenAddress: bytesToHexString(order.sell_token),
+    sellAmount: (order.sell_amount),
+    buyTokenAddress: bytesToHexString(order.buy_token),
+    buyAmount: (order.buy_amount),
+  }
+}

--- a/libs/repositories/src/repos/ExpiredOrdersRepository/expiredOrdersUtils.ts
+++ b/libs/repositories/src/repos/ExpiredOrdersRepository/expiredOrdersUtils.ts
@@ -4,6 +4,7 @@ import { bytesToHexString } from '../../utils/bytesUtils';
 export function parseExpiredOrder(order: ExpiredOrder): ParsedExpiredOrder {
   return {
     uid: bytesToHexString(order.uid),
+    kind: order.kind,
     validTo: order.valid_to,
     owner: bytesToHexString(order.owner),
     sellTokenAddress: bytesToHexString(order.sell_token),

--- a/libs/repositories/src/utils/bytesUtils.ts
+++ b/libs/repositories/src/utils/bytesUtils.ts
@@ -1,0 +1,7 @@
+export function bytesToHexString(bytes: Buffer): string {
+  return '0x' + bytes.toString('hex')
+}
+
+export function hexStringToBytes(hex: string): Buffer {
+  return Buffer.from(hex.slice(2), 'hex')
+}

--- a/libs/services/src/factories.ts
+++ b/libs/services/src/factories.ts
@@ -34,12 +34,13 @@ import {
   createNewPostgresPool,
   createTelegramBot,
   getViemClients,
-  redisClient
+  redisClient,
+  ExpiredOrdersRepository,
+  ExpiredOrdersRepositoryPostgres
 } from '@cowprotocol/repositories';
 
 import ms from 'ms';
 import { Pool } from 'pg';
-import { DataSource } from 'typeorm';
 
 const DEFAULT_CACHE_VALUE_SECONDS = ms('2min') / 1000; // 2min cache time by default for values
 const DEFAULT_CACHE_NULL_SECONDS = ms('30min') / 1000; // 30min cache time by default for NULL values (when the repository isn't known)
@@ -166,6 +167,10 @@ export function getIndexerStateRepository(): IndexerStateRepository {
 
 export function getOnChainPlacedOrdersRepository(): OnChainPlacedOrdersRepository {
   return new OnChainPlacedOrdersRepositoryPostgres();
+}
+
+export function getExpiredOrdersRepository(): ExpiredOrdersRepository {
+  return new ExpiredOrdersRepositoryPostgres();
 }
 
 export function getSimulationRepository(): SimulationRepository {


### PR DESCRIPTION
1. Added a new producer `ExpiredOrdersNotificationProducer`
2. The producer periodically (once in ~14sec) checks OrderBook DB and selects expired orders
3. Order is considered as expired when:
 - validTo > lastCheck && validTo <= now
 - AND it's not filled
4. Order is considered as filled when sum of sell/buy amounts from `trades` table is less than order sell/buy amount 