### PR TITLE
feat: add user balance repository

### DIFF
--- a/libs/repositories/src/gen/cow/cow-api-types.ts
+++ b/libs/repositories/src/gen/cow/cow-api-types.ts
@@ -4,1801 +4,1871 @@
  */
 
 export interface paths {
-    "/api/v1/orders": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+  '/api/v1/orders': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create a new order. In order to replace an existing order with a new one, the appData must contain a [valid replacement order UID](https://github.com/cowprotocol/app-data/blob/main/src/schemas/v1.1.0.json#L62), then the indicated order is cancelled, and a new one placed.
+     *     This allows an old order to be cancelled AND a new order to be created in an atomic operation with a single signature.
+     *     This may be useful for replacing orders when on-chain prices move outside of the original order's limit price. */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      /** @description The order to create. */
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['OrderCreation'];
         };
-        get?: never;
-        put?: never;
-        /** Create a new order. In order to replace an existing order with a new one, the appData must contain a [valid replacement order UID](https://github.com/cowprotocol/app-data/blob/main/src/schemas/v1.1.0.json#L62), then the indicated order is cancelled, and a new one placed.
-         *     This allows an old order to be cancelled AND a new order to be created in an atomic operation with a single signature.
-         *     This may be useful for replacing orders when on-chain prices move outside of the original order's limit price. */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description The order to create. */
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["OrderCreation"];
-                };
-            };
-            responses: {
-                /** @description Order has been accepted. */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["UID"];
-                    };
-                };
-                /** @description Error during order validation. */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["OrderPostError"];
-                    };
-                };
-                /** @description Forbidden, your account is deny-listed. */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description No route was found quoting the order. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Too many order placements. */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Error adding an order. */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+      };
+      responses: {
+        /** @description Order has been accepted. */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['UID'];
+          };
         };
-        /**
-         * Cancel multiple orders by marking them invalid with a timestamp.
-         * @description This is a *best effort* cancellation, and might not prevent solvers from settling the orders (if the order is part of an in-flight settlement transaction for example). Authentication must be provided by an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of an `OrderCancellations(bytes[] orderUids)` message.
+        /** @description Error during order validation. */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['OrderPostError'];
+          };
+        };
+        /** @description Forbidden, your account is deny-listed. */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description No route was found quoting the order. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Too many order placements. */
+        429: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Error adding an order. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    /**
+     * Cancel multiple orders by marking them invalid with a timestamp.
+     * @description This is a *best effort* cancellation, and might not prevent solvers from settling the orders (if the order is part of an in-flight settlement transaction for example). Authentication must be provided by an [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of an `OrderCancellations(bytes[] orderUids)` message.
+     *
+     */
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      /** @description Signed `OrderCancellations`. */
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['OrderCancellations'];
+        };
+      };
+      responses: {
+        /** @description Order(s) are cancelled. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Malformed signature. */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['OrderCancellationError'];
+          };
+        };
+        /** @description Invalid signature. */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description One or more orders were not found and no orders were cancelled. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/orders/{UID}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get existing order from UID. */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          UID: components['schemas']['UID'];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Order */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['Order'];
+          };
+        };
+        /** @description Order was not found. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    /**
+     * Cancel an order by marking it invalid with a timestamp.
+     * @deprecated
+     * @description The successful deletion might not prevent solvers from settling the
+     *     order.
+     *
+     *     Authentication must be provided by providing an
+     *     [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of an
+     *     `OrderCancellation(bytes orderUid)` message.
+     */
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          UID: components['schemas']['UID'];
+        };
+        cookie?: never;
+      };
+      /** @description Signed `OrderCancellation` */
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['OrderCancellation'];
+        };
+      };
+      responses: {
+        /** @description Order cancelled. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Malformed signature. */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['OrderCancellationError'];
+          };
+        };
+        /** @description Invalid signature. */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Order was not found. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/orders/{UID}/status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the status of an order. */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          UID: components['schemas']['UID'];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description The order status with a list of solvers that proposed solutions (if applicable). */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['CompetitionOrderStatus'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/transactions/{txHash}/orders': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get orders by settlement transaction hash. */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          txHash: components['schemas']['TransactionHash'];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Order(s). */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['Order'][];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/trades': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get existing trades.
+     * @description Exactly one of `owner` or `orderUid` must be set.
+     *
+     */
+    get: {
+      parameters: {
+        query?: {
+          owner?: components['schemas']['Address'];
+          orderUid?: components['schemas']['UID'];
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description ### If `owner` is specified:
          *
-         */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description Signed `OrderCancellations`. */
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["OrderCancellations"];
-                };
-            };
-            responses: {
-                /** @description Order(s) are cancelled. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Malformed signature. */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["OrderCancellationError"];
-                    };
-                };
-                /** @description Invalid signature. */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description One or more orders were not found and no orders were cancelled. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/orders/{UID}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get existing order from UID. */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    UID: components["schemas"]["UID"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Order */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Order"];
-                    };
-                };
-                /** @description Order was not found. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        /**
-         * Cancel an order by marking it invalid with a timestamp.
-         * @deprecated
-         * @description The successful deletion might not prevent solvers from settling the
-         *     order.
+         *     Return all trades related to that `owner`.
          *
-         *     Authentication must be provided by providing an
-         *     [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of an
-         *     `OrderCancellation(bytes orderUid)` message.
-         */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    UID: components["schemas"]["UID"];
-                };
-                cookie?: never;
-            };
-            /** @description Signed `OrderCancellation` */
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["OrderCancellation"];
-                };
-            };
-            responses: {
-                /** @description Order cancelled. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Malformed signature. */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["OrderCancellationError"];
-                    };
-                };
-                /** @description Invalid signature. */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Order was not found. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/orders/{UID}/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get the status of an order. */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    UID: components["schemas"]["UID"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description The order status with a list of solvers that proposed solutions (if applicable). */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["CompetitionOrderStatus"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/transactions/{txHash}/orders": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get orders by settlement transaction hash. */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    txHash: components["schemas"]["TransactionHash"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Order(s). */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Order"][];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/trades": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get existing trades.
-         * @description Exactly one of `owner` or `orderUid` must be set.
+         *     ### If `orderUid` is specified:
          *
-         */
-        get: {
-            parameters: {
-                query?: {
-                    owner?: components["schemas"]["Address"];
-                    orderUid?: components["schemas"]["UID"];
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description ### If `owner` is specified:
-                 *
-                 *     Return all trades related to that `owner`.
-                 *
-                 *     ### If `orderUid` is specified:
-                 *
-                 *     Return all trades related to that `orderUid`. Given that an order
-                 *     may be partially fillable, it is possible that an individual order
-                 *     may have *multiple* trades. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Trade"][];
-                    };
-                };
-            };
+         *     Return all trades related to that `orderUid`. Given that an order
+         *     may be partially fillable, it is possible that an individual order
+         *     may have *multiple* trades. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['Trade'][];
+          };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/v1/auction": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get the current batch auction.
-         * @description The current batch auction that solvers should be solving right now. This
-         *     includes:
-         *
-         *     * A list of solvable orders. * The block on which the batch was created.
-         *     * Prices for all tokens being traded (used for objective value
-         *     computation).
-         *
-         *     **Note: This endpoint is currently permissioned. Reach out in discord if
-         *     you need access.**
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Batch auction. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Auction"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/auction': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/account/{owner}/orders": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    /**
+     * Get the current batch auction.
+     * @description The current batch auction that solvers should be solving right now. This
+     *     includes:
+     *
+     *     * A list of solvable orders. * The block on which the batch was created.
+     *     * Prices for all tokens being traded (used for objective value
+     *     computation).
+     *
+     *     **Note: This endpoint is currently permissioned. Reach out in discord if
+     *     you need access.**
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Batch auction. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['Auction'];
+          };
         };
-        /**
-         * Get orders of one user paginated.
-         * @description The orders are sorted by their creation date descending (newest orders
-         *     first).
-         *
-         *     To enumerate all orders start with `offset` 0 and keep increasing the
-         *     `offset` by the total number of returned results. When a response
-         *     contains less than `limit` the last page has been reached.
-         */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description The pagination offset. Defaults to 0.
-                     *      */
-                    offset?: number;
-                    /** @description The pagination limit. Defaults to 10. Maximum 1000. Minimum 1.
-                     *      */
-                    limit?: number;
-                };
-                header?: never;
-                path: {
-                    owner: components["schemas"]["Address"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description The orders. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Order"][];
-                    };
-                };
-                /** @description Problem with parameters like limit being too large. */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/v1/token/{token}/native_price": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get native price for the given token.
-         * @description Price is the exchange rate between the specified token and the network's
-         *     native currency.
-         *
-         *     It represents the amount of native token atoms needed to buy 1 atom of
-         *     the specified token.
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: components["schemas"]["Address"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description The estimated native price. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["NativePriceResponse"];
-                    };
-                };
-                /** @description Error finding the price. */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description No liquidity was found. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Unexpected error. */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/account/{owner}/orders': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/quote": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    /**
+     * Get orders of one user paginated.
+     * @description The orders are sorted by their creation date descending (newest orders
+     *     first).
+     *
+     *     To enumerate all orders start with `offset` 0 and keep increasing the
+     *     `offset` by the total number of returned results. When a response
+     *     contains less than `limit` the last page has been reached.
+     */
+    get: {
+      parameters: {
+        query?: {
+          /** @description The pagination offset. Defaults to 0.
+           *      */
+          offset?: number;
+          /** @description The pagination limit. Defaults to 10. Maximum 1000. Minimum 1.
+           *      */
+          limit?: number;
         };
-        get?: never;
-        put?: never;
-        /**
-         * Quote a price and fee for the specified order parameters.
-         * @description Given a partial order compute the minimum fee and a price estimate for the order. Return a full order that can be used directly for signing, and with an included signature, passed directly to the order creation endpoint.
-         *
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description The order parameters to compute a quote for. */
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["OrderQuoteRequest"];
-                };
-            };
-            responses: {
-                /** @description Quoted order. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["OrderQuoteResponse"];
-                    };
-                };
-                /** @description Error quoting order. */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PriceEstimationError"];
-                    };
-                };
-                /** @description No route was found for the specified order. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Too many order quotes. */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Unexpected error quoting an order. */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+        header?: never;
+        path: {
+          owner: components['schemas']['Address'];
         };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description The orders. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['Order'][];
+          };
+        };
+        /** @description Problem with parameters like limit being too large. */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/v1/solver_competition/{auction_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get information about a solver competition.
-         * @deprecated
-         * @description Returns the competition information by `auction_id`.
-         *
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    auction_id: number;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Competition */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SolverCompetitionResponse"];
-                    };
-                };
-                /** @description No competition information available for this auction id. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/token/{token}/native_price': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/solver_competition/by_tx_hash/{tx_hash}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    /**
+     * Get native price for the given token.
+     * @description Price is the exchange rate between the specified token and the network's
+     *     native currency.
+     *
+     *     It represents the amount of native token atoms needed to buy 1 atom of
+     *     the specified token.
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          token: components['schemas']['Address'];
         };
-        /**
-         * Get information about solver competition.
-         * @deprecated
-         * @description Returns the competition information by `tx_hash`.
-         *
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Transaction hash in which the competition was settled. */
-                    tx_hash: components["schemas"]["TransactionHash"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Competition */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SolverCompetitionResponse"];
-                    };
-                };
-                /** @description No competition information available for this `tx_hash`. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description The estimated native price. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['NativePriceResponse'];
+          };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Error finding the price. */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description No liquidity was found. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Unexpected error. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/v1/solver_competition/latest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get information about the most recent solver competition.
-         * @deprecated
-         * @description Returns the competition information for the last seen auction_id.
-         *
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Competition */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SolverCompetitionResponse"];
-                    };
-                };
-                /** @description No competition information available. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/quote': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v2/solver_competition/{auction_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Quote a price and fee for the specified order parameters.
+     * @description Given a partial order compute the minimum fee and a price estimate for the order. Return a full order that can be used directly for signing, and with an included signature, passed directly to the order creation endpoint.
+     *
+     */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      /** @description The order parameters to compute a quote for. */
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['OrderQuoteRequest'];
         };
-        /**
-         * Get information about a solver competition.
-         * @description Returns the competition information by `auction_id`.
-         *
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    auction_id: number;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Competition */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SolverCompetitionResponse"];
-                    };
-                };
-                /** @description No competition information available for this auction id. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+      };
+      responses: {
+        /** @description Quoted order. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['OrderQuoteResponse'];
+          };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description Error quoting order. */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['PriceEstimationError'];
+          };
+        };
+        /** @description No route was found for the specified order. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Too many order quotes. */
+        429: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Unexpected error quoting an order. */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/v2/solver_competition/by_tx_hash/{tx_hash}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get information about solver competition.
-         * @description Returns the competition information by `tx_hash`.
-         *
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Transaction hash in which the competition was settled. */
-                    tx_hash: components["schemas"]["TransactionHash"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Competition */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SolverCompetitionResponse"];
-                    };
-                };
-                /** @description No competition information available for this `tx_hash`. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/solver_competition/{auction_id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v2/solver_competition/latest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    /**
+     * Get information about a solver competition.
+     * @deprecated
+     * @description Returns the competition information by `auction_id`.
+     *
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          auction_id: number;
         };
-        /**
-         * Get information about the most recent solver competition.
-         * @description Returns the competition information for the last seen auction_id.
-         *
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Competition */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SolverCompetitionResponse"];
-                    };
-                };
-                /** @description No competition information available. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Competition */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['SolverCompetitionResponse'];
+          };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+        /** @description No competition information available for this auction id. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
     };
-    "/api/v1/version": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get the API's current deployed version.
-         * @description Returns the git commit hash, branch name and release tag (code: https://github.com/cowprotocol/services).
-         *
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Version */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/plain": unknown;
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/solver_competition/by_tx_hash/{tx_hash}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/app_data/{app_data_hash}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    /**
+     * Get information about solver competition.
+     * @deprecated
+     * @description Returns the competition information by `tx_hash`.
+     *
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          /** @description Transaction hash in which the competition was settled. */
+          tx_hash: components['schemas']['TransactionHash'];
         };
-        /** Get the full `appData` from contract `appDataHash`. */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    app_data_hash: components["schemas"]["AppDataHash"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Full `appData`. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AppDataObject"];
-                    };
-                };
-                /** @description No full `appData` stored for this hash. */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Competition */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['SolverCompetitionResponse'];
+          };
         };
-        /**
-         * Registers a full `appData` so it can be referenced by `appDataHash`.
-         * @description Uploads a full `appData` to orderbook so that orders created with the corresponding `appDataHash` can be linked to the original full `appData`.
-         *
-         */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    app_data_hash: components["schemas"]["AppDataHash"];
-                };
-                cookie?: never;
-            };
-            /** @description The `appData` document to upload. */
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["AppDataObject"];
-                };
-            };
-            responses: {
-                /** @description The full `appData` already exists. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AppDataHash"];
-                    };
-                };
-                /** @description The full `appData` was successfully registered. */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AppDataHash"];
-                    };
-                };
-                /** @description Error validating full `appData` */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Error storing the full `appData` */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
+        /** @description No competition information available for this `tx_hash`. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
         };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
-    "/api/v1/app_data": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /**
-         * Registers a full `appData` and returns `appDataHash`.
-         * @description Uploads a full `appData` to orderbook and returns the corresponding `appDataHash`.
-         *
-         */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            /** @description The `appData` document to upload. */
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["AppDataObject"];
-                };
-            };
-            responses: {
-                /** @description The full `appData` already exists. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AppDataHash"];
-                    };
-                };
-                /** @description The full `appData` was successfully registered. */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AppDataHash"];
-                    };
-                };
-                /** @description Error validating full `appData` */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Error storing the full `appData` */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/solver_competition/latest': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/api/v1/users/{address}/total_surplus": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    /**
+     * Get information about the most recent solver competition.
+     * @deprecated
+     * @description Returns the competition information for the last seen auction_id.
+     *
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Competition */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['SolverCompetitionResponse'];
+          };
         };
-        /**
-         * Get the total surplus earned by the user. [UNSTABLE]
-         * @description ### Caution
-         *
-         *     This endpoint is under active development and should NOT be considered
-         *     stable.
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    address: components["schemas"]["Address"];
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description The total surplus. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TotalSurplus"];
-                    };
-                };
-            };
+        /** @description No competition information available. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+      };
     };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v2/solver_competition/{auction_id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get information about a solver competition.
+     * @description Returns the competition information by `auction_id`.
+     *
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          auction_id: number;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Competition */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['SolverCompetitionResponse'];
+          };
+        };
+        /** @description No competition information available for this auction id. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v2/solver_competition/by_tx_hash/{tx_hash}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get information about solver competition.
+     * @description Returns the competition information by `tx_hash`.
+     *
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          /** @description Transaction hash in which the competition was settled. */
+          tx_hash: components['schemas']['TransactionHash'];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Competition */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['SolverCompetitionResponse'];
+          };
+        };
+        /** @description No competition information available for this `tx_hash`. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v2/solver_competition/latest': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get information about the most recent solver competition.
+     * @description Returns the competition information for the last seen auction_id.
+     *
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Competition */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['SolverCompetitionResponse'];
+          };
+        };
+        /** @description No competition information available. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/version': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get the API's current deployed version.
+     * @description Returns the git commit hash, branch name and release tag (code: https://github.com/cowprotocol/services).
+     *
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Version */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'text/plain': unknown;
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/app_data/{app_data_hash}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the full `appData` from contract `appDataHash`. */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          app_data_hash: components['schemas']['AppDataHash'];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Full `appData`. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['AppDataObject'];
+          };
+        };
+        /** @description No full `appData` stored for this hash. */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    /**
+     * Registers a full `appData` so it can be referenced by `appDataHash`.
+     * @description Uploads a full `appData` to orderbook so that orders created with the corresponding `appDataHash` can be linked to the original full `appData`.
+     *
+     */
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          app_data_hash: components['schemas']['AppDataHash'];
+        };
+        cookie?: never;
+      };
+      /** @description The `appData` document to upload. */
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['AppDataObject'];
+        };
+      };
+      responses: {
+        /** @description The full `appData` already exists. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['AppDataHash'];
+          };
+        };
+        /** @description The full `appData` was successfully registered. */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['AppDataHash'];
+          };
+        };
+        /** @description Error validating full `appData` */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Error storing the full `appData` */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/app_data': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /**
+     * Registers a full `appData` and returns `appDataHash`.
+     * @description Uploads a full `appData` to orderbook and returns the corresponding `appDataHash`.
+     *
+     */
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      /** @description The `appData` document to upload. */
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['AppDataObject'];
+        };
+      };
+      responses: {
+        /** @description The full `appData` already exists. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['AppDataHash'];
+          };
+        };
+        /** @description The full `appData` was successfully registered. */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['AppDataHash'];
+          };
+        };
+        /** @description Error validating full `appData` */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Error storing the full `appData` */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/users/{address}/total_surplus': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get the total surplus earned by the user. [UNSTABLE]
+     * @description ### Caution
+     *
+     *     This endpoint is under active development and should NOT be considered
+     *     stable.
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          address: components['schemas']['Address'];
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description The total surplus. */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['TotalSurplus'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        /**
-         * @description 32 byte digest encoded as a hex with `0x` prefix.
-         * @example 0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5
-         */
-        TransactionHash: string;
-        /**
-         * @description 20 byte Ethereum address encoded as a hex with `0x` prefix.
-         * @example 0x6810e776880c02933d47db1b9fc05908e5386b96
-         */
-        Address: string;
-        /**
-         * @description The string encoding of a JSON object representing some `appData`. The
-         *     format of the JSON expected in the `appData` field is defined
-         *     [here](https://github.com/cowprotocol/app-data).
-         *
-         * @example {"version":"0.9.0","metadata":{}}
-         */
-        AppData: string;
-        /**
-         * @description 32 bytes encoded as hex with `0x` prefix.
-         *     It's expected to be the hash of the stringified JSON object representing the `appData`.
-         *
-         * @example 0x0000000000000000000000000000000000000000000000000000000000000000
-         */
-        AppDataHash: string;
-        /** @description An `appData` document that is registered with the API. */
-        AppDataObject: {
-            fullAppData?: components["schemas"]["AppData"];
-        };
-        /**
-         * @description A big unsigned integer encoded in decimal.
-         * @example 1234567890
-         */
-        BigUint: string;
-        /**
-         * @description Some `calldata` sent to a contract in a transaction encoded as a hex with `0x` prefix.
-         * @example 0xca11da7a
-         */
-        CallData: string;
-        /**
-         * @description Amount of a token. `uint256` encoded in decimal.
-         * @example 1234567890
-         */
-        TokenAmount: string;
-        OnchainOrderData: {
-            /** @description If orders are placed as on-chain orders, the owner of the order might be a smart contract, but not the user placing the order. The actual user will be provided in this field.
-             *      */
-            sender: components["schemas"]["Address"];
-            /**
-             * @description Describes the error, if the order placement was not successful. This could happen, for example, if the `validTo` is too high, or no valid quote was found or generated.
-             *
-             * @enum {string}
-             */
-            placementError?: "QuoteNotFound" | "ValidToTooFarInFuture" | "PreValidationError";
-        };
-        /** @description Provides the additional data for ethflow orders. */
-        EthflowData: {
-            /** @description Specifies in which transaction the order was refunded. If
-             *     this field is null the order was not yet refunded.
-             *      */
-            refundTxHash: components["schemas"]["TransactionHash"] | null;
-            /** @description Describes the `validTo` of an order ethflow order.
-             *
-             *     **NOTE**: For ethflow orders, the `validTo` encoded in the smart
-             *     contract is `type(uint256).max`.
-             *      */
-            userValidTo: number;
-        };
-        /**
-         * @description Is this order a buy or sell?
-         * @enum {string}
-         */
-        OrderKind: "buy" | "sell";
-        /**
-         * @description Order class.
-         * @enum {string}
-         */
-        OrderClass: "market" | "limit" | "liquidity";
-        /**
-         * @description Where should the `sellToken` be drawn from?
-         * @enum {string}
-         */
-        SellTokenSource: "erc20" | "internal" | "external";
-        /**
-         * @description Where should the `buyToken` be transferred to?
-         * @enum {string}
-         */
-        BuyTokenDestination: "erc20" | "internal";
-        /**
-         * @description How good should the price estimate be?
-         *
-         *     Fast: The price estimate is chosen among the fastest N price estimates.
-         *     Optimal: The price estimate is chosen among all price estimates.
-         *     Verified: The price estimate is chosen among all verified/simulated
-         *     price estimates.
-         *
-         *     **NOTE**: Orders are supposed to be created from `verified` or `optimal`
-         *     price estimates.
-         * @enum {string}
-         */
-        PriceQuality: "fast" | "optimal" | "verified";
-        /**
-         * @description The current order status.
-         * @enum {string}
-         */
-        OrderStatus: "presignaturePending" | "open" | "fulfilled" | "cancelled" | "expired";
-        /** @description Order parameters. */
-        OrderParameters: {
-            /** @description ERC-20 token to be sold. */
-            sellToken: components["schemas"]["Address"];
-            /** @description ERC-20 token to be bought. */
-            buyToken: components["schemas"]["Address"];
-            /** @description An optional Ethereum address to receive the proceeds of the trade instead of the owner (i.e. the order signer).
-             *      */
-            receiver?: components["schemas"]["Address"] | null;
-            /** @description Amount of `sellToken` to be sold in atoms. */
-            sellAmount: components["schemas"]["TokenAmount"];
-            /** @description Amount of `buyToken` to be bought in atoms. */
-            buyAmount: components["schemas"]["TokenAmount"];
-            /** @description Unix timestamp (`uint32`) until which the order is valid. */
-            validTo: number;
-            appData: components["schemas"]["AppDataHash"];
-            /** @description sellAmount in atoms to cover network fees. Needs to be zero (and incorporated into the limit price) when placing the order */
-            feeAmount: components["schemas"]["TokenAmount"];
-            /** @description The kind is either a buy or sell order. */
-            kind: components["schemas"]["OrderKind"];
-            /** @description Is the order fill-or-kill or partially fillable? */
-            partiallyFillable: boolean;
-            /** @default erc20 */
-            sellTokenBalance: components["schemas"]["SellTokenSource"];
-            /** @default erc20 */
-            buyTokenBalance: components["schemas"]["BuyTokenDestination"];
-            /** @default eip712 */
-            signingScheme: components["schemas"]["SigningScheme"];
-        };
-        /** @description Data a user provides when creating a new order. */
-        OrderCreation: {
-            /** @description see `OrderParameters::sellToken` */
-            sellToken: components["schemas"]["Address"];
-            /** @description see `OrderParameters::buyToken` */
-            buyToken: components["schemas"]["Address"];
-            /** @description see `OrderParameters::receiver` */
-            receiver?: components["schemas"]["Address"] | null;
-            /** @description see `OrderParameters::sellAmount` */
-            sellAmount: components["schemas"]["TokenAmount"];
-            /** @description see `OrderParameters::buyAmount` */
-            buyAmount: components["schemas"]["TokenAmount"];
-            /** @description see `OrderParameters::validTo` */
-            validTo: number;
-            /** @description see `OrderParameters::feeAmount` */
-            feeAmount: components["schemas"]["TokenAmount"];
-            /** @description see `OrderParameters::kind` */
-            kind: components["schemas"]["OrderKind"];
-            /** @description see `OrderParameters::partiallyFillable` */
-            partiallyFillable: boolean;
-            /**
-             * @description see `OrderParameters::sellTokenBalance`
-             * @default erc20
-             */
-            sellTokenBalance: components["schemas"]["SellTokenSource"];
-            /**
-             * @description see `OrderParameters::buyTokenBalance`
-             * @default erc20
-             */
-            buyTokenBalance: components["schemas"]["BuyTokenDestination"];
-            signingScheme: components["schemas"]["SigningScheme"];
-            signature: components["schemas"]["Signature"];
-            /** @description If set, the backend enforces that this address matches what is decoded as the *signer* of the signature. This helps catch errors with invalid signature encodings as the backend might otherwise silently work with an unexpected address that for example does not have any balance.
-             *      */
-            from?: components["schemas"]["Address"] | null;
-            /** @description Orders can optionally include a quote ID. This way the order can be linked to a quote and enable providing more metadata when analysing order slippage.
-             *      */
-            quoteId?: number | null;
-            /** @description This field comes in two forms for backward compatibility. The hash form will eventually stop being accepted.
-             *      */
-            appData: (string & components["schemas"]["AppData"]) | components["schemas"]["AppDataHash"];
-            /** @description May be set for debugging purposes. If set, this field is compared to what the backend internally calculates as the app data hash based on the contents of `appData`. If the hash does not match, an error is returned. If this field is set, then `appData` **MUST** be a string encoding of a JSON object.
-             *      */
-            appDataHash?: components["schemas"]["AppDataHash"] | null;
-        };
-        /** @description Extra order data that is returned to users when querying orders but not provided by users when creating orders.
-         *      */
-        OrderMetaData: {
-            /**
-             * @description Creation time of the order. Encoded as ISO 8601 UTC.
-             * @example 2020-12-03T18:35:18.814523Z
-             */
-            creationDate: string;
-            class: components["schemas"]["OrderClass"];
-            owner: components["schemas"]["Address"];
-            uid: components["schemas"]["UID"];
-            /**
-             * @deprecated
-             * @description Unused field that is currently always set to `null` and will be removed in the future.
-             *
-             */
-            availableBalance?: components["schemas"]["TokenAmount"] | null;
-            /** @description The total amount of `sellToken` that has been transferred from the user for this order so far.
-             *      */
-            executedSellAmount: components["schemas"]["BigUint"];
-            /** @description The total amount of `sellToken` that has been transferred from the user for this order so far minus tokens that were transferred as part of the signed `fee` of the order. This is only relevant for old orders because now all orders have a signed `fee` of 0 and solvers compute an appropriate fee dynamically at the time of the order execution.
-             *      */
-            executedSellAmountBeforeFees: components["schemas"]["BigUint"];
-            /** @description The total amount of `buyToken` that has been executed for this order.
-             *      */
-            executedBuyAmount: components["schemas"]["BigUint"];
-            /** @description [DEPRECATED] The total amount of the user signed `fee` that have been executed for this order. This value is only non-negative for very old orders.
-             *      */
-            executedFeeAmount: components["schemas"]["BigUint"];
-            /** @description Has this order been invalidated? */
-            invalidated: boolean;
-            /** @description Order status. */
-            status: components["schemas"]["OrderStatus"];
-            /** @description Liquidity orders are functionally the same as normal smart contract
-             *     orders but are not placed with the intent of actively getting
-             *     traded. Instead they facilitate the trade of normal orders by
-             *     allowing them to be matched against liquidity orders which uses less
-             *     gas and can have better prices than external liquidity.
-             *
-             *     As such liquidity orders will only be used in order to improve
-             *     settlement of normal orders. They should not be expected to be
-             *     traded otherwise and should not expect to get surplus. */
-            isLiquidityOrder?: boolean;
-            ethflowData?: components["schemas"]["EthflowData"];
-            /** @description This represents the actual trader of an on-chain order.
-             *     ### ethflow orders
-             *     In this case, the `owner` would be the `EthFlow` contract and *not* the actual trader.
-             *      */
-            onchainUser?: components["schemas"]["Address"];
-            /** @description There is some data only available for orders that are placed on-chain. This data can be found in this object.
-             *      */
-            onchainOrderData?: components["schemas"]["OnchainOrderData"];
-            /** @description Total fee charged for execution of the order. Contains network fee and protocol fees. This takes into account the historic static fee signed by the user and the new dynamic fee computed by solvers.
-             *      */
-            executedFee?: components["schemas"]["BigUint"];
-            /** @description Token the executed fee was captured in. */
-            executedFeeToken?: components["schemas"]["Address"];
-            /** @description Full `appData`, which the contract-level `appData` is a hash of. See `OrderCreation` for more information.
-             *      */
-            fullAppData?: string | null;
-        };
-        Order: components["schemas"]["OrderCreation"] & components["schemas"]["OrderMetaData"];
-        /** @description A solvable order included in the current batch auction. Contains the data forwarded to solvers for solving.
-         *      */
-        AuctionOrder: {
-            uid: components["schemas"]["UID"];
-            /** @description see `OrderParameters::sellToken` */
-            sellToken: components["schemas"]["Address"];
-            /** @description see `OrderParameters::buyToken` */
-            buyToken: components["schemas"]["Address"];
-            /** @description see `OrderParameters::sellAmount` */
-            sellAmount: components["schemas"]["TokenAmount"];
-            /** @description see `OrderParameters::buyAmount` */
-            buyAmount: components["schemas"]["TokenAmount"];
-            /**
-             * @description Creation time of the order. Denominated in epoch seconds.
-             * @example 123456
-             */
-            created: string;
-            /** @description see `OrderParameters::validTo` */
-            validTo: number;
-            /** @description see `OrderParameters::kind` */
-            kind: components["schemas"]["OrderKind"];
-            /** @description see `OrderParameters::receiver` */
-            receiver: components["schemas"]["Address"] | null;
-            owner: components["schemas"]["Address"];
-            /** @description see `OrderParameters::partiallyFillable` */
-            partiallyFillable: boolean;
-            /** @description Currently executed amount of sell/buy token, depending on the order kind.
-             *      */
-            executed: components["schemas"]["TokenAmount"];
-            /** @description The pre-interactions that need to be executed before the first execution of the order.
-             *      */
-            preInteractions: components["schemas"]["InteractionData"][];
-            /** @description The post-interactions that need to be executed after the execution of the order.
-             *      */
-            postInteractions: components["schemas"]["InteractionData"][];
-            /**
-             * @description see `OrderParameters::sellTokenBalance`
-             * @default erc20
-             */
-            sellTokenBalance: components["schemas"]["SellTokenSource"];
-            /**
-             * @description see `OrderParameters::buyTokenBalance`
-             * @default erc20
-             */
-            buyTokenBalance: components["schemas"]["BuyTokenDestination"];
-            class: components["schemas"]["OrderClass"];
-            appData: components["schemas"]["AppDataHash"];
-            signature: components["schemas"]["Signature"];
-            /** @description The fee policies that are used to compute the protocol fees for this order.
-             *      */
-            protocolFees: components["schemas"]["FeePolicy"][];
-            /** @description A winning quote.
-             *      */
-            quote?: components["schemas"]["Quote"];
-        };
-        /** @description A batch auction for solving.
-         *      */
-        Auction: {
-            /** @description The unique identifier of the auction. Increment whenever the backend creates a new auction.
-             *      */
-            id?: number;
-            /** @description The block number for the auction. Orders and prices are guaranteed to be valid on this block. Proposed settlements should be valid for this block as well.
-             *      */
-            block?: number;
-            /** @description The solvable orders included in the auction.
-             *      */
-            orders?: components["schemas"]["AuctionOrder"][];
-            prices?: components["schemas"]["AuctionPrices"];
-            /** @description List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
-             *      */
-            surplusCapturingJitOrderOwners?: components["schemas"]["Address"][];
-        };
-        /** @description The components that describe a batch auction for the solver competition.
-         *      */
-        CompetitionAuction: {
-            /** @description The UIDs of the orders included in the auction.
-             *      */
-            orders?: components["schemas"]["UID"][];
-            prices?: components["schemas"]["AuctionPrices"];
-        };
-        ExecutedAmounts: {
-            sell: components["schemas"]["BigUint"];
-            buy: components["schemas"]["BigUint"];
-        };
-        CompetitionOrderStatus: {
-            /** @enum {string} */
-            type: "open" | "scheduled" | "active" | "solved" | "executing" | "traded" | "cancelled";
-            /** @description A list of solvers who participated in the latest competition, sorted
-             *     by score in ascending order, where the last element is the winner.
-             *
-             *     The presence of executed amounts defines whether the solver provided
-             *     a solution for the desired order. */
-            value?: {
-                /** @description Name of the solver. */
-                solver: string;
-                executedAmounts?: components["schemas"]["ExecutedAmounts"];
-            }[];
-        };
-        /** @description The reference prices for all traded tokens in the auction as a mapping from token addresses to a price denominated in native token (i.e. 1e18 represents a token that trades one to one with the native token). These prices are used for solution competition for computing surplus and converting fees to native token.
-         *      */
-        AuctionPrices: {
-            [key: string]: components["schemas"]["BigUint"] | undefined;
-        };
-        /** @description EIP-712 signature of struct OrderCancellations { orderUid: bytes[] } from the order's owner.
-         *      */
-        OrderCancellations: {
-            /** @description UIDs of orders to cancel. */
-            orderUids?: components["schemas"]["UID"][];
-            /** @description `OrderCancellation` signed by the owner. */
-            signature: components["schemas"]["EcdsaSignature"];
-            signingScheme: components["schemas"]["EcdsaSigningScheme"];
-        };
-        /** @description [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of struct
-         *     `OrderCancellation(bytes orderUid)` from the order's owner.
-         *      */
-        OrderCancellation: {
-            /** @description OrderCancellation signed by owner */
-            signature: components["schemas"]["EcdsaSignature"];
-            signingScheme: components["schemas"]["EcdsaSigningScheme"];
-        };
-        /** @description Trade data such as executed amounts, fees, `orderUid` and `block` number.
-         *      */
-        Trade: {
-            /** @description Block in which trade occurred. */
-            blockNumber: number;
-            /** @description Index in which transaction was included in block. */
-            logIndex: number;
-            /** @description UID of the order matched by this trade. */
-            orderUid: components["schemas"]["UID"];
-            /** @description Address of trader. */
-            owner: components["schemas"]["Address"];
-            /** @description Address of token sold. */
-            sellToken: components["schemas"]["Address"];
-            /** @description Address of token bought. */
-            buyToken: components["schemas"]["Address"];
-            /** @description Total amount of `sellToken` that has been executed for this trade (including fees). */
-            sellAmount: components["schemas"]["TokenAmount"];
-            /** @description The total amount of `sellToken` that has been executed for this order without fees. */
-            sellAmountBeforeFees: components["schemas"]["BigUint"];
-            /** @description Total amount of `buyToken` received in this trade. */
-            buyAmount: components["schemas"]["TokenAmount"];
-            /** @description Transaction hash of the corresponding settlement transaction containing the trade (if available). */
-            txHash: components["schemas"]["TransactionHash"] | null;
-            /** @description Executed protocol fees for this trade, together with the fee policies used. Listed in the order they got applied.
-             *      */
-            executedProtocolFees?: components["schemas"]["ExecutedProtocolFee"][];
-        };
-        /**
-         * @description Unique identifier for the order: 56 bytes encoded as hex with `0x`
-         *     prefix.
-         *
-         *     Bytes 0..32 are the order digest, bytes 30..52 the owner address and
-         *     bytes 52..56 the expiry (`validTo`) as a `uint32` unix epoch timestamp.
-         * @example 0xff2e2e54d178997f173266817c1e9ed6fee1a1aae4b43971c53b543cffcc2969845c6f5599fbb25dbdd1b9b013daf85c03f3c63763e4bc4a
-         */
-        UID: string;
-        /**
-         * @description How was the order signed?
-         * @enum {string}
-         */
-        SigningScheme: "eip712" | "ethsign" | "presign" | "eip1271";
-        /**
-         * @description How was the order signed?
-         * @enum {string}
-         */
-        EcdsaSigningScheme: "eip712" | "ethsign";
-        /** @description A signature. */
-        Signature: components["schemas"]["EcdsaSignature"] | components["schemas"]["PreSignature"];
-        /**
-         * @description 65 bytes encoded as hex with `0x` prefix. `r || s || v` from the spec.
-         * @example 0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
-         */
-        EcdsaSignature: string;
-        /**
-         * @description Empty signature bytes. Used for "presign" signatures.
-         * @example 0x
-         */
-        PreSignature: string;
-        OrderPostError: {
-            /** @enum {string} */
-            errorType: "DuplicatedOrder" | "QuoteNotFound" | "QuoteNotVerified" | "InvalidQuote" | "MissingFrom" | "WrongOwner" | "InvalidEip1271Signature" | "InsufficientBalance" | "InsufficientAllowance" | "InvalidSignature" | "SellAmountOverflow" | "TransferSimulationFailed" | "ZeroAmount" | "IncompatibleSigningScheme" | "TooManyLimitOrders" | "TooMuchGas" | "UnsupportedBuyTokenDestination" | "UnsupportedSellTokenSource" | "UnsupportedOrderType" | "InsufficientValidTo" | "ExcessiveValidTo" | "InvalidNativeSellToken" | "SameBuyAndSellToken" | "UnsupportedToken" | "InvalidAppData" | "AppDataHashMismatch" | "AppdataFromMismatch" | "OldOrderActivelyBidOn";
-            description: string;
-        };
-        OrderCancellationError: {
-            /** @enum {string} */
-            errorType: "InvalidSignature" | "WrongOwner" | "OrderNotFound" | "AlreadyCancelled" | "OrderFullyExecuted" | "OrderExpired" | "OnChainOrder";
-            description: string;
-        };
-        PriceEstimationError: {
-            /** @enum {string} */
-            errorType: "QuoteNotVerified" | "UnsupportedToken" | "ZeroAmount" | "UnsupportedOrderType";
-            description: string;
-        };
-        /** @description The buy or sell side when quoting an order. */
-        OrderQuoteSide: {
-            kind: components["schemas"]["OrderQuoteSideKindSell"];
-            /** @description The total amount that is available for the order. From this value, the fee is deducted and the buy amount is calculated.
-             *      */
-            sellAmountBeforeFee: components["schemas"]["TokenAmount"];
-        } | {
-            kind: components["schemas"]["OrderQuoteSideKindSell"];
-            /** @description The `sellAmount` for the order. */
-            sellAmountAfterFee: components["schemas"]["TokenAmount"];
-        } | {
-            kind: components["schemas"]["OrderQuoteSideKindBuy"];
-            /** @description The `buyAmount` for the order. */
-            buyAmountAfterFee: components["schemas"]["TokenAmount"];
-        };
-        /** @enum {string} */
-        OrderQuoteSideKindSell: "sell";
-        /** @enum {string} */
-        OrderQuoteSideKindBuy: "buy";
-        /** @description The validity for the order. */
-        OrderQuoteValidity: {
-            /** @description Unix timestamp (`uint32`) until which the order is valid. */
-            validTo?: number;
-        } | {
-            /** @description Number (`uint32`) of seconds that the order should be valid for. */
-            validFor?: number;
-        };
-        /** @description Request fee and price quote. */
-        OrderQuoteRequest: components["schemas"]["OrderQuoteSide"] & components["schemas"]["OrderQuoteValidity"] & {
-            /** @description ERC-20 token to be sold */
-            sellToken: components["schemas"]["Address"];
-            /** @description ERC-20 token to be bought */
-            buyToken: components["schemas"]["Address"];
-            /** @description An optional address to receive the proceeds of the trade instead of the
-             *     `owner` (i.e. the order signer).
-             *      */
-            receiver?: components["schemas"]["Address"] | null;
-            /** @description AppData which will be assigned to the order.
-             *
-             *     Expects either a string JSON doc as defined on
-             *     [AppData](https://github.com/cowprotocol/app-data) or a hex
-             *     encoded string for backwards compatibility.
-             *
-             *     When the first format is used, it's possible to provide the
-             *     derived appDataHash field. */
-            appData?: components["schemas"]["AppData"] | components["schemas"]["AppDataHash"];
-            /** @description The hash of the stringified JSON appData doc.
-             *
-             *     If present, `appData` field must be set with the aforementioned
-             *     data where this hash is derived from.
-             *
-             *     In case they differ, the call will fail. */
-            appDataHash?: components["schemas"]["AppDataHash"];
-            /** @default erc20 */
-            sellTokenBalance: components["schemas"]["SellTokenSource"];
-            /** @default erc20 */
-            buyTokenBalance: components["schemas"]["BuyTokenDestination"];
-            from: components["schemas"]["Address"];
-            /** @default verified */
-            priceQuality: components["schemas"]["PriceQuality"];
-            /** @default eip712 */
-            signingScheme: components["schemas"]["SigningScheme"];
-            /**
-             * @description Flag to signal whether the order is intended for on-chain order placement. Only valid for non ECDSA-signed orders."
-             *
-             * @default false
-             */
-            onchainOrder: unknown;
-            /** @description User provided timeout in milliseconds. Can only be used to reduce the response time for quote requests if the default is too slow as values greater than the default will be capped to the default. Note that reducing the timeout can result in worse quotes because the reduced timeout might be too slow for some price estimators.
-             *      */
-            timeout?: number;
-        };
-        /** @description An order quoted by the backend that can be directly signed and
-         *     submitted to the order creation backend.
-         *      */
-        OrderQuoteResponse: {
-            quote: components["schemas"]["OrderParameters"];
-            from?: components["schemas"]["Address"];
-            /**
-             * @description Expiration date of the offered fee. Order service might not accept
-             *     the fee after this expiration date. Encoded as ISO 8601 UTC.
-             *
-             * @example 1985-03-10T18:35:18.814523Z
-             */
-            expiration: string;
-            /** @description Quote ID linked to a quote to enable providing more metadata when analysing order slippage.
-             *      */
-            id?: number;
-            /** @description Whether it was possible to verify that the quoted amounts are accurate using a simulation.
-             *      */
-            verified: boolean;
-        };
-        /** @description The settlements submitted by every solver for a specific auction.
-         *     The `auctionId` corresponds to the id external solvers are provided
-         *     with.
-         *      */
-        SolverCompetitionResponse: {
-            /** @description The ID of the auction the competition info is for. */
-            auctionId?: number;
-            /** @description Block that the auction started on. */
-            auctionStartBlock?: number;
-            /** @description The hashes of the transactions for the winning solutions of this competition.
-             *      */
-            transactionHashes?: components["schemas"]["TransactionHash"][];
-            /** @description The reference scores for each winning solver according to [CIP-67](https://forum.cow.fi/t/cip-67-moving-from-batch-auction-to-the-fair-combinatorial-auction/2967) (if available).
-             *      */
-            referenceScores?: {
-                [key: string]: components["schemas"]["BigUint"] | undefined;
-            };
-            auction?: components["schemas"]["CompetitionAuction"];
-            /** @description Maps from solver name to object describing that solver's settlement. */
-            solutions?: components["schemas"]["SolverSettlement"][];
-        };
-        SolverSettlement: {
-            /** @description Which position the solution achieved in the total ranking of the competition. */
-            ranking?: number;
-            /** @description The address used by the solver to execute the settlement on-chain.
-             *
-             *     This field is missing for old settlements, the zero address has been
-             *     used instead. */
-            solverAddress?: string;
-            /** @description The score of the current auction as defined in [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f).
-             *      */
-            score?: components["schemas"]["BigUint"];
-            /** @description The reference score as defined in [CIP-67](https://forum.cow.fi/t/cip-67-moving-from-batch-auction-to-the-fair-combinatorial-auction/2967) (if available).
-             *      */
-            referenceScore?: components["schemas"]["BigUint"] | null;
-            /** @description Transaction in which the solution was executed onchain (if available).
-             *      */
-            txHash?: components["schemas"]["TransactionHash"] | null;
-            /** @description The prices of tokens for settled user orders as passed to the settlement contract.
-             *      */
-            clearingPrices?: {
-                [key: string]: components["schemas"]["BigUint"] | undefined;
-            };
-            /** @description Touched orders. */
-            orders?: {
-                id?: components["schemas"]["UID"];
-                sellAmount?: components["schemas"]["BigUint"];
-                buyAmount?: components["schemas"]["BigUint"];
-            }[];
-            /** @description whether the solution is a winner (received the right to get executed) or not */
-            isWinner?: boolean;
-            /** @description whether the solution was filtered out according to the rules of [CIP-67](https://forum.cow.fi/t/cip-67-moving-from-batch-auction-to-the-fair-combinatorial-auction/2967). */
-            filteredOut?: boolean;
-        };
-        /** @description The estimated native price for the token
-         *      */
-        NativePriceResponse: {
-            /** @description Estimated price of the token. */
-            price?: number;
-        };
-        /** @description The total surplus.
-         *      */
-        TotalSurplus: {
-            /** @description The total surplus. */
-            totalSurplus?: string;
-        };
-        InteractionData: {
-            target?: components["schemas"]["Address"];
-            value?: components["schemas"]["TokenAmount"];
-            /** @description The call data to be used for the interaction. */
-            call_data?: components["schemas"]["CallData"][];
-        };
-        /** @description A calculated order quote.
-         *      */
-        Quote: {
-            /** @description The amount of the sell token. */
-            sellAmount?: components["schemas"]["TokenAmount"];
-            /** @description The amount of the buy token. */
-            buyAmount?: components["schemas"]["TokenAmount"];
-            /** @description The amount that needs to be paid, denominated in the sell token. */
-            fee?: components["schemas"]["TokenAmount"];
-        };
-        /** @description The protocol fee is taken as a percent of the surplus. */
-        Surplus: {
-            factor: number;
-            maxVolumeFactor: number;
-        };
-        /** @description The protocol fee is taken as a percent of the order volume. */
-        Volume: {
-            factor: number;
-        };
-        /** @description The protocol fee is taken as a percent of the order price improvement which is a difference between the executed price and the best quote. */
-        PriceImprovement: {
-            factor: number;
-            maxVolumeFactor: number;
-            /** @description The best quote received. */
-            quote: components["schemas"]["Quote"];
-        };
-        /** @description Defines the ways to calculate the protocol fee. */
-        FeePolicy: components["schemas"]["Surplus"] | components["schemas"]["Volume"] | components["schemas"]["PriceImprovement"];
-        ExecutedProtocolFee: {
-            policy?: components["schemas"]["FeePolicy"];
-            amount?: unknown & components["schemas"]["TokenAmount"];
-            token?: unknown & components["schemas"]["Address"];
-        };
+  schemas: {
+    /**
+     * @description 32 byte digest encoded as a hex with `0x` prefix.
+     * @example 0xd51f28edffcaaa76be4a22f6375ad289272c037f3cc072345676e88d92ced8b5
+     */
+    TransactionHash: string;
+    /**
+     * @description 20 byte Ethereum address encoded as a hex with `0x` prefix.
+     * @example 0x6810e776880c02933d47db1b9fc05908e5386b96
+     */
+    Address: string;
+    /**
+     * @description The string encoding of a JSON object representing some `appData`. The
+     *     format of the JSON expected in the `appData` field is defined
+     *     [here](https://github.com/cowprotocol/app-data).
+     *
+     * @example {"version":"0.9.0","metadata":{}}
+     */
+    AppData: string;
+    /**
+     * @description 32 bytes encoded as hex with `0x` prefix.
+     *     It's expected to be the hash of the stringified JSON object representing the `appData`.
+     *
+     * @example 0x0000000000000000000000000000000000000000000000000000000000000000
+     */
+    AppDataHash: string;
+    /** @description An `appData` document that is registered with the API. */
+    AppDataObject: {
+      fullAppData?: components['schemas']['AppData'];
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    /**
+     * @description A big unsigned integer encoded in decimal.
+     * @example 1234567890
+     */
+    BigUint: string;
+    /**
+     * @description Some `calldata` sent to a contract in a transaction encoded as a hex with `0x` prefix.
+     * @example 0xca11da7a
+     */
+    CallData: string;
+    /**
+     * @description Amount of a token. `uint256` encoded in decimal.
+     * @example 1234567890
+     */
+    TokenAmount: string;
+    OnchainOrderData: {
+      /** @description If orders are placed as on-chain orders, the owner of the order might be a smart contract, but not the user placing the order. The actual user will be provided in this field.
+       *      */
+      sender: components['schemas']['Address'];
+      /**
+       * @description Describes the error, if the order placement was not successful. This could happen, for example, if the `validTo` is too high, or no valid quote was found or generated.
+       *
+       * @enum {string}
+       */
+      placementError?:
+        | 'QuoteNotFound'
+        | 'ValidToTooFarInFuture'
+        | 'PreValidationError';
+    };
+    /** @description Provides the additional data for ethflow orders. */
+    EthflowData: {
+      /** @description Specifies in which transaction the order was refunded. If
+       *     this field is null the order was not yet refunded.
+       *      */
+      refundTxHash: components['schemas']['TransactionHash'] | null;
+      /** @description Describes the `validTo` of an order ethflow order.
+       *
+       *     **NOTE**: For ethflow orders, the `validTo` encoded in the smart
+       *     contract is `type(uint256).max`.
+       *      */
+      userValidTo: number;
+    };
+    /**
+     * @description Is this order a buy or sell?
+     * @enum {string}
+     */
+    OrderKind: 'buy' | 'sell';
+    /**
+     * @description Order class.
+     * @enum {string}
+     */
+    OrderClass: 'market' | 'limit' | 'liquidity';
+    /**
+     * @description Where should the `sellToken` be drawn from?
+     * @enum {string}
+     */
+    SellTokenSource: 'erc20' | 'internal' | 'external';
+    /**
+     * @description Where should the `buyToken` be transferred to?
+     * @enum {string}
+     */
+    BuyTokenDestination: 'erc20' | 'internal';
+    /**
+     * @description How good should the price estimate be?
+     *
+     *     Fast: The price estimate is chosen among the fastest N price estimates.
+     *     Optimal: The price estimate is chosen among all price estimates.
+     *     Verified: The price estimate is chosen among all verified/simulated
+     *     price estimates.
+     *
+     *     **NOTE**: Orders are supposed to be created from `verified` or `optimal`
+     *     price estimates.
+     * @enum {string}
+     */
+    PriceQuality: 'fast' | 'optimal' | 'verified';
+    /**
+     * @description The current order status.
+     * @enum {string}
+     */
+    OrderStatus:
+      | 'presignaturePending'
+      | 'open'
+      | 'fulfilled'
+      | 'cancelled'
+      | 'expired';
+    /** @description Order parameters. */
+    OrderParameters: {
+      /** @description ERC-20 token to be sold. */
+      sellToken: components['schemas']['Address'];
+      /** @description ERC-20 token to be bought. */
+      buyToken: components['schemas']['Address'];
+      /** @description An optional Ethereum address to receive the proceeds of the trade instead of the owner (i.e. the order signer).
+       *      */
+      receiver?: components['schemas']['Address'] | null;
+      /** @description Amount of `sellToken` to be sold in atoms. */
+      sellAmount: components['schemas']['TokenAmount'];
+      /** @description Amount of `buyToken` to be bought in atoms. */
+      buyAmount: components['schemas']['TokenAmount'];
+      /** @description Unix timestamp (`uint32`) until which the order is valid. */
+      validTo: number;
+      appData: components['schemas']['AppDataHash'];
+      /** @description sellAmount in atoms to cover network fees. Needs to be zero (and incorporated into the limit price) when placing the order */
+      feeAmount: components['schemas']['TokenAmount'];
+      /** @description The kind is either a buy or sell order. */
+      kind: components['schemas']['OrderKind'];
+      /** @description Is the order fill-or-kill or partially fillable? */
+      partiallyFillable: boolean;
+      /** @default erc20 */
+      sellTokenBalance: components['schemas']['SellTokenSource'];
+      /** @default erc20 */
+      buyTokenBalance: components['schemas']['BuyTokenDestination'];
+      /** @default eip712 */
+      signingScheme: components['schemas']['SigningScheme'];
+    };
+    /** @description Data a user provides when creating a new order. */
+    OrderCreation: {
+      /** @description see `OrderParameters::sellToken` */
+      sellToken: components['schemas']['Address'];
+      /** @description see `OrderParameters::buyToken` */
+      buyToken: components['schemas']['Address'];
+      /** @description see `OrderParameters::receiver` */
+      receiver?: components['schemas']['Address'] | null;
+      /** @description see `OrderParameters::sellAmount` */
+      sellAmount: components['schemas']['TokenAmount'];
+      /** @description see `OrderParameters::buyAmount` */
+      buyAmount: components['schemas']['TokenAmount'];
+      /** @description see `OrderParameters::validTo` */
+      validTo: number;
+      /** @description see `OrderParameters::feeAmount` */
+      feeAmount: components['schemas']['TokenAmount'];
+      /** @description see `OrderParameters::kind` */
+      kind: components['schemas']['OrderKind'];
+      /** @description see `OrderParameters::partiallyFillable` */
+      partiallyFillable: boolean;
+      /**
+       * @description see `OrderParameters::sellTokenBalance`
+       * @default erc20
+       */
+      sellTokenBalance: components['schemas']['SellTokenSource'];
+      /**
+       * @description see `OrderParameters::buyTokenBalance`
+       * @default erc20
+       */
+      buyTokenBalance: components['schemas']['BuyTokenDestination'];
+      signingScheme: components['schemas']['SigningScheme'];
+      signature: components['schemas']['Signature'];
+      /** @description If set, the backend enforces that this address matches what is decoded as the *signer* of the signature. This helps catch errors with invalid signature encodings as the backend might otherwise silently work with an unexpected address that for example does not have any balance.
+       *      */
+      from?: components['schemas']['Address'] | null;
+      /** @description Orders can optionally include a quote ID. This way the order can be linked to a quote and enable providing more metadata when analysing order slippage.
+       *      */
+      quoteId?: number | null;
+      /** @description This field comes in two forms for backward compatibility. The hash form will eventually stop being accepted.
+       *      */
+      appData:
+        | (string & components['schemas']['AppData'])
+        | components['schemas']['AppDataHash'];
+      /** @description May be set for debugging purposes. If set, this field is compared to what the backend internally calculates as the app data hash based on the contents of `appData`. If the hash does not match, an error is returned. If this field is set, then `appData` **MUST** be a string encoding of a JSON object.
+       *      */
+      appDataHash?: components['schemas']['AppDataHash'] | null;
+    };
+    /** @description Extra order data that is returned to users when querying orders but not provided by users when creating orders.
+     *      */
+    OrderMetaData: {
+      /**
+       * @description Creation time of the order. Encoded as ISO 8601 UTC.
+       * @example 2020-12-03T18:35:18.814523Z
+       */
+      creationDate: string;
+      class: components['schemas']['OrderClass'];
+      owner: components['schemas']['Address'];
+      uid: components['schemas']['UID'];
+      /**
+       * @deprecated
+       * @description Unused field that is currently always set to `null` and will be removed in the future.
+       *
+       */
+      availableBalance?: components['schemas']['TokenAmount'] | null;
+      /** @description The total amount of `sellToken` that has been transferred from the user for this order so far.
+       *      */
+      executedSellAmount: components['schemas']['BigUint'];
+      /** @description The total amount of `sellToken` that has been transferred from the user for this order so far minus tokens that were transferred as part of the signed `fee` of the order. This is only relevant for old orders because now all orders have a signed `fee` of 0 and solvers compute an appropriate fee dynamically at the time of the order execution.
+       *      */
+      executedSellAmountBeforeFees: components['schemas']['BigUint'];
+      /** @description The total amount of `buyToken` that has been executed for this order.
+       *      */
+      executedBuyAmount: components['schemas']['BigUint'];
+      /** @description [DEPRECATED] The total amount of the user signed `fee` that have been executed for this order. This value is only non-negative for very old orders.
+       *      */
+      executedFeeAmount: components['schemas']['BigUint'];
+      /** @description Has this order been invalidated? */
+      invalidated: boolean;
+      /** @description Order status. */
+      status: components['schemas']['OrderStatus'];
+      /** @description Liquidity orders are functionally the same as normal smart contract
+       *     orders but are not placed with the intent of actively getting
+       *     traded. Instead they facilitate the trade of normal orders by
+       *     allowing them to be matched against liquidity orders which uses less
+       *     gas and can have better prices than external liquidity.
+       *
+       *     As such liquidity orders will only be used in order to improve
+       *     settlement of normal orders. They should not be expected to be
+       *     traded otherwise and should not expect to get surplus. */
+      isLiquidityOrder?: boolean;
+      ethflowData?: components['schemas']['EthflowData'];
+      /** @description This represents the actual trader of an on-chain order.
+       *     ### ethflow orders
+       *     In this case, the `owner` would be the `EthFlow` contract and *not* the actual trader.
+       *      */
+      onchainUser?: components['schemas']['Address'];
+      /** @description There is some data only available for orders that are placed on-chain. This data can be found in this object.
+       *      */
+      onchainOrderData?: components['schemas']['OnchainOrderData'];
+      /** @description Total fee charged for execution of the order. Contains network fee and protocol fees. This takes into account the historic static fee signed by the user and the new dynamic fee computed by solvers.
+       *      */
+      executedFee?: components['schemas']['BigUint'];
+      /** @description Token the executed fee was captured in. */
+      executedFeeToken?: components['schemas']['Address'];
+      /** @description Full `appData`, which the contract-level `appData` is a hash of. See `OrderCreation` for more information.
+       *      */
+      fullAppData?: string | null;
+    };
+    Order: components['schemas']['OrderCreation'] &
+      components['schemas']['OrderMetaData'];
+    /** @description A solvable order included in the current batch auction. Contains the data forwarded to solvers for solving.
+     *      */
+    AuctionOrder: {
+      uid: components['schemas']['UID'];
+      /** @description see `OrderParameters::sellToken` */
+      sellToken: components['schemas']['Address'];
+      /** @description see `OrderParameters::buyToken` */
+      buyToken: components['schemas']['Address'];
+      /** @description see `OrderParameters::sellAmount` */
+      sellAmount: components['schemas']['TokenAmount'];
+      /** @description see `OrderParameters::buyAmount` */
+      buyAmount: components['schemas']['TokenAmount'];
+      /**
+       * @description Creation time of the order. Denominated in epoch seconds.
+       * @example 123456
+       */
+      created: string;
+      /** @description see `OrderParameters::validTo` */
+      validTo: number;
+      /** @description see `OrderParameters::kind` */
+      kind: components['schemas']['OrderKind'];
+      /** @description see `OrderParameters::receiver` */
+      receiver: components['schemas']['Address'] | null;
+      owner: components['schemas']['Address'];
+      /** @description see `OrderParameters::partiallyFillable` */
+      partiallyFillable: boolean;
+      /** @description Currently executed amount of sell/buy token, depending on the order kind.
+       *      */
+      executed: components['schemas']['TokenAmount'];
+      /** @description The pre-interactions that need to be executed before the first execution of the order.
+       *      */
+      preInteractions: components['schemas']['InteractionData'][];
+      /** @description The post-interactions that need to be executed after the execution of the order.
+       *      */
+      postInteractions: components['schemas']['InteractionData'][];
+      /**
+       * @description see `OrderParameters::sellTokenBalance`
+       * @default erc20
+       */
+      sellTokenBalance: components['schemas']['SellTokenSource'];
+      /**
+       * @description see `OrderParameters::buyTokenBalance`
+       * @default erc20
+       */
+      buyTokenBalance: components['schemas']['BuyTokenDestination'];
+      class: components['schemas']['OrderClass'];
+      appData: components['schemas']['AppDataHash'];
+      signature: components['schemas']['Signature'];
+      /** @description The fee policies that are used to compute the protocol fees for this order.
+       *      */
+      protocolFees: components['schemas']['FeePolicy'][];
+      /** @description A winning quote.
+       *      */
+      quote?: components['schemas']['Quote'];
+    };
+    /** @description A batch auction for solving.
+     *      */
+    Auction: {
+      /** @description The unique identifier of the auction. Increment whenever the backend creates a new auction.
+       *      */
+      id?: number;
+      /** @description The block number for the auction. Orders and prices are guaranteed to be valid on this block. Proposed settlements should be valid for this block as well.
+       *      */
+      block?: number;
+      /** @description The solvable orders included in the auction.
+       *      */
+      orders?: components['schemas']['AuctionOrder'][];
+      prices?: components['schemas']['AuctionPrices'];
+      /** @description List of addresses on whose surplus will count towards the objective value of their solution (unlike other orders that were created by the solver).
+       *      */
+      surplusCapturingJitOrderOwners?: components['schemas']['Address'][];
+    };
+    /** @description The components that describe a batch auction for the solver competition.
+     *      */
+    CompetitionAuction: {
+      /** @description The UIDs of the orders included in the auction.
+       *      */
+      orders?: components['schemas']['UID'][];
+      prices?: components['schemas']['AuctionPrices'];
+    };
+    ExecutedAmounts: {
+      sell: components['schemas']['BigUint'];
+      buy: components['schemas']['BigUint'];
+    };
+    CompetitionOrderStatus: {
+      /** @enum {string} */
+      type:
+        | 'open'
+        | 'scheduled'
+        | 'active'
+        | 'solved'
+        | 'executing'
+        | 'traded'
+        | 'cancelled';
+      /** @description A list of solvers who participated in the latest competition, sorted
+       *     by score in ascending order, where the last element is the winner.
+       *
+       *     The presence of executed amounts defines whether the solver provided
+       *     a solution for the desired order. */
+      value?: {
+        /** @description Name of the solver. */
+        solver: string;
+        executedAmounts?: components['schemas']['ExecutedAmounts'];
+      }[];
+    };
+    /** @description The reference prices for all traded tokens in the auction as a mapping from token addresses to a price denominated in native token (i.e. 1e18 represents a token that trades one to one with the native token). These prices are used for solution competition for computing surplus and converting fees to native token.
+     *      */
+    AuctionPrices: {
+      [key: string]: components['schemas']['BigUint'] | undefined;
+    };
+    /** @description EIP-712 signature of struct OrderCancellations { orderUid: bytes[] } from the order's owner.
+     *      */
+    OrderCancellations: {
+      /** @description UIDs of orders to cancel. */
+      orderUids?: components['schemas']['UID'][];
+      /** @description `OrderCancellation` signed by the owner. */
+      signature: components['schemas']['EcdsaSignature'];
+      signingScheme: components['schemas']['EcdsaSigningScheme'];
+    };
+    /** @description [EIP-712](https://eips.ethereum.org/EIPS/eip-712) signature of struct
+     *     `OrderCancellation(bytes orderUid)` from the order's owner.
+     *      */
+    OrderCancellation: {
+      /** @description OrderCancellation signed by owner */
+      signature: components['schemas']['EcdsaSignature'];
+      signingScheme: components['schemas']['EcdsaSigningScheme'];
+    };
+    /** @description Trade data such as executed amounts, fees, `orderUid` and `block` number.
+     *      */
+    Trade: {
+      /** @description Block in which trade occurred. */
+      blockNumber: number;
+      /** @description Index in which transaction was included in block. */
+      logIndex: number;
+      /** @description UID of the order matched by this trade. */
+      orderUid: components['schemas']['UID'];
+      /** @description Address of trader. */
+      owner: components['schemas']['Address'];
+      /** @description Address of token sold. */
+      sellToken: components['schemas']['Address'];
+      /** @description Address of token bought. */
+      buyToken: components['schemas']['Address'];
+      /** @description Total amount of `sellToken` that has been executed for this trade (including fees). */
+      sellAmount: components['schemas']['TokenAmount'];
+      /** @description The total amount of `sellToken` that has been executed for this order without fees. */
+      sellAmountBeforeFees: components['schemas']['BigUint'];
+      /** @description Total amount of `buyToken` received in this trade. */
+      buyAmount: components['schemas']['TokenAmount'];
+      /** @description Transaction hash of the corresponding settlement transaction containing the trade (if available). */
+      txHash: components['schemas']['TransactionHash'] | null;
+      /** @description Executed protocol fees for this trade, together with the fee policies used. Listed in the order they got applied.
+       *      */
+      executedProtocolFees?: components['schemas']['ExecutedProtocolFee'][];
+    };
+    /**
+     * @description Unique identifier for the order: 56 bytes encoded as hex with `0x`
+     *     prefix.
+     *
+     *     Bytes 0..32 are the order digest, bytes 30..52 the owner address and
+     *     bytes 52..56 the expiry (`validTo`) as a `uint32` unix epoch timestamp.
+     * @example 0xff2e2e54d178997f173266817c1e9ed6fee1a1aae4b43971c53b543cffcc2969845c6f5599fbb25dbdd1b9b013daf85c03f3c63763e4bc4a
+     */
+    UID: string;
+    /**
+     * @description How was the order signed?
+     * @enum {string}
+     */
+    SigningScheme: 'eip712' | 'ethsign' | 'presign' | 'eip1271';
+    /**
+     * @description How was the order signed?
+     * @enum {string}
+     */
+    EcdsaSigningScheme: 'eip712' | 'ethsign';
+    /** @description A signature. */
+    Signature:
+      | components['schemas']['EcdsaSignature']
+      | components['schemas']['PreSignature'];
+    /**
+     * @description 65 bytes encoded as hex with `0x` prefix. `r || s || v` from the spec.
+     * @example 0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+     */
+    EcdsaSignature: string;
+    /**
+     * @description Empty signature bytes. Used for "presign" signatures.
+     * @example 0x
+     */
+    PreSignature: string;
+    OrderPostError: {
+      /** @enum {string} */
+      errorType:
+        | 'DuplicatedOrder'
+        | 'QuoteNotFound'
+        | 'QuoteNotVerified'
+        | 'InvalidQuote'
+        | 'MissingFrom'
+        | 'WrongOwner'
+        | 'InvalidEip1271Signature'
+        | 'InsufficientBalance'
+        | 'InsufficientAllowance'
+        | 'InvalidSignature'
+        | 'SellAmountOverflow'
+        | 'TransferSimulationFailed'
+        | 'ZeroAmount'
+        | 'IncompatibleSigningScheme'
+        | 'TooManyLimitOrders'
+        | 'TooMuchGas'
+        | 'UnsupportedBuyTokenDestination'
+        | 'UnsupportedSellTokenSource'
+        | 'UnsupportedOrderType'
+        | 'InsufficientValidTo'
+        | 'ExcessiveValidTo'
+        | 'InvalidNativeSellToken'
+        | 'SameBuyAndSellToken'
+        | 'UnsupportedToken'
+        | 'InvalidAppData'
+        | 'AppDataHashMismatch'
+        | 'AppdataFromMismatch'
+        | 'OldOrderActivelyBidOn';
+      description: string;
+    };
+    OrderCancellationError: {
+      /** @enum {string} */
+      errorType:
+        | 'InvalidSignature'
+        | 'WrongOwner'
+        | 'OrderNotFound'
+        | 'AlreadyCancelled'
+        | 'OrderFullyExecuted'
+        | 'OrderExpired'
+        | 'OnChainOrder';
+      description: string;
+    };
+    PriceEstimationError: {
+      /** @enum {string} */
+      errorType:
+        | 'QuoteNotVerified'
+        | 'UnsupportedToken'
+        | 'ZeroAmount'
+        | 'UnsupportedOrderType';
+      description: string;
+    };
+    /** @description The buy or sell side when quoting an order. */
+    OrderQuoteSide:
+      | {
+          kind: components['schemas']['OrderQuoteSideKindSell'];
+          /** @description The total amount that is available for the order. From this value, the fee is deducted and the buy amount is calculated.
+           *      */
+          sellAmountBeforeFee: components['schemas']['TokenAmount'];
+        }
+      | {
+          kind: components['schemas']['OrderQuoteSideKindSell'];
+          /** @description The `sellAmount` for the order. */
+          sellAmountAfterFee: components['schemas']['TokenAmount'];
+        }
+      | {
+          kind: components['schemas']['OrderQuoteSideKindBuy'];
+          /** @description The `buyAmount` for the order. */
+          buyAmountAfterFee: components['schemas']['TokenAmount'];
+        };
+    /** @enum {string} */
+    OrderQuoteSideKindSell: 'sell';
+    /** @enum {string} */
+    OrderQuoteSideKindBuy: 'buy';
+    /** @description The validity for the order. */
+    OrderQuoteValidity:
+      | {
+          /** @description Unix timestamp (`uint32`) until which the order is valid. */
+          validTo?: number;
+        }
+      | {
+          /** @description Number (`uint32`) of seconds that the order should be valid for. */
+          validFor?: number;
+        };
+    /** @description Request fee and price quote. */
+    OrderQuoteRequest: components['schemas']['OrderQuoteSide'] &
+      components['schemas']['OrderQuoteValidity'] & {
+        /** @description ERC-20 token to be sold */
+        sellToken: components['schemas']['Address'];
+        /** @description ERC-20 token to be bought */
+        buyToken: components['schemas']['Address'];
+        /** @description An optional address to receive the proceeds of the trade instead of the
+         *     `owner` (i.e. the order signer).
+         *      */
+        receiver?: components['schemas']['Address'] | null;
+        /** @description AppData which will be assigned to the order.
+         *
+         *     Expects either a string JSON doc as defined on
+         *     [AppData](https://github.com/cowprotocol/app-data) or a hex
+         *     encoded string for backwards compatibility.
+         *
+         *     When the first format is used, it's possible to provide the
+         *     derived appDataHash field. */
+        appData?:
+          | components['schemas']['AppData']
+          | components['schemas']['AppDataHash'];
+        /** @description The hash of the stringified JSON appData doc.
+         *
+         *     If present, `appData` field must be set with the aforementioned
+         *     data where this hash is derived from.
+         *
+         *     In case they differ, the call will fail. */
+        appDataHash?: components['schemas']['AppDataHash'];
+        /** @default erc20 */
+        sellTokenBalance: components['schemas']['SellTokenSource'];
+        /** @default erc20 */
+        buyTokenBalance: components['schemas']['BuyTokenDestination'];
+        from: components['schemas']['Address'];
+        /** @default verified */
+        priceQuality: components['schemas']['PriceQuality'];
+        /** @default eip712 */
+        signingScheme: components['schemas']['SigningScheme'];
+        /**
+         * @description Flag to signal whether the order is intended for on-chain order placement. Only valid for non ECDSA-signed orders."
+         *
+         * @default false
+         */
+        onchainOrder: unknown;
+        /** @description User provided timeout in milliseconds. Can only be used to reduce the response time for quote requests if the default is too slow as values greater than the default will be capped to the default. Note that reducing the timeout can result in worse quotes because the reduced timeout might be too slow for some price estimators.
+         *      */
+        timeout?: number;
+      };
+    /** @description An order quoted by the backend that can be directly signed and
+     *     submitted to the order creation backend.
+     *      */
+    OrderQuoteResponse: {
+      quote: components['schemas']['OrderParameters'];
+      from?: components['schemas']['Address'];
+      /**
+       * @description Expiration date of the offered fee. Order service might not accept
+       *     the fee after this expiration date. Encoded as ISO 8601 UTC.
+       *
+       * @example 1985-03-10T18:35:18.814523Z
+       */
+      expiration: string;
+      /** @description Quote ID linked to a quote to enable providing more metadata when analysing order slippage.
+       *      */
+      id?: number;
+      /** @description Whether it was possible to verify that the quoted amounts are accurate using a simulation.
+       *      */
+      verified: boolean;
+    };
+    /** @description The settlements submitted by every solver for a specific auction.
+     *     The `auctionId` corresponds to the id external solvers are provided
+     *     with.
+     *      */
+    SolverCompetitionResponse: {
+      /** @description The ID of the auction the competition info is for. */
+      auctionId?: number;
+      /** @description Block that the auction started on. */
+      auctionStartBlock?: number;
+      /** @description The hashes of the transactions for the winning solutions of this competition.
+       *      */
+      transactionHashes?: components['schemas']['TransactionHash'][];
+      /** @description The reference scores for each winning solver according to [CIP-67](https://forum.cow.fi/t/cip-67-moving-from-batch-auction-to-the-fair-combinatorial-auction/2967) (if available).
+       *      */
+      referenceScores?: {
+        [key: string]: components['schemas']['BigUint'] | undefined;
+      };
+      auction?: components['schemas']['CompetitionAuction'];
+      /** @description Maps from solver name to object describing that solver's settlement. */
+      solutions?: components['schemas']['SolverSettlement'][];
+    };
+    SolverSettlement: {
+      /** @description Which position the solution achieved in the total ranking of the competition. */
+      ranking?: number;
+      /** @description The address used by the solver to execute the settlement on-chain.
+       *
+       *     This field is missing for old settlements, the zero address has been
+       *     used instead. */
+      solverAddress?: string;
+      /** @description The score of the current auction as defined in [CIP-20](https://snapshot.org/#/cow.eth/proposal/0x2d3f9bd1ea72dca84b03e97dda3efc1f4a42a772c54bd2037e8b62e7d09a491f).
+       *      */
+      score?: components['schemas']['BigUint'];
+      /** @description The reference score as defined in [CIP-67](https://forum.cow.fi/t/cip-67-moving-from-batch-auction-to-the-fair-combinatorial-auction/2967) (if available).
+       *      */
+      referenceScore?: components['schemas']['BigUint'] | null;
+      /** @description Transaction in which the solution was executed onchain (if available).
+       *      */
+      txHash?: components['schemas']['TransactionHash'] | null;
+      /** @description The prices of tokens for settled user orders as passed to the settlement contract.
+       *      */
+      clearingPrices?: {
+        [key: string]: components['schemas']['BigUint'] | undefined;
+      };
+      /** @description Touched orders. */
+      orders?: {
+        id?: components['schemas']['UID'];
+        sellAmount?: components['schemas']['BigUint'];
+        buyAmount?: components['schemas']['BigUint'];
+      }[];
+      /** @description whether the solution is a winner (received the right to get executed) or not */
+      isWinner?: boolean;
+      /** @description whether the solution was filtered out according to the rules of [CIP-67](https://forum.cow.fi/t/cip-67-moving-from-batch-auction-to-the-fair-combinatorial-auction/2967). */
+      filteredOut?: boolean;
+    };
+    /** @description The estimated native price for the token
+     *      */
+    NativePriceResponse: {
+      /** @description Estimated price of the token. */
+      price?: number;
+    };
+    /** @description The total surplus.
+     *      */
+    TotalSurplus: {
+      /** @description The total surplus. */
+      totalSurplus?: string;
+    };
+    InteractionData: {
+      target?: components['schemas']['Address'];
+      value?: components['schemas']['TokenAmount'];
+      /** @description The call data to be used for the interaction. */
+      call_data?: components['schemas']['CallData'][];
+    };
+    /** @description A calculated order quote.
+     *      */
+    Quote: {
+      /** @description The amount of the sell token. */
+      sellAmount?: components['schemas']['TokenAmount'];
+      /** @description The amount of the buy token. */
+      buyAmount?: components['schemas']['TokenAmount'];
+      /** @description The amount that needs to be paid, denominated in the sell token. */
+      fee?: components['schemas']['TokenAmount'];
+    };
+    /** @description The protocol fee is taken as a percent of the surplus. */
+    Surplus: {
+      factor: number;
+      maxVolumeFactor: number;
+    };
+    /** @description The protocol fee is taken as a percent of the order volume. */
+    Volume: {
+      factor: number;
+    };
+    /** @description The protocol fee is taken as a percent of the order price improvement which is a difference between the executed price and the best quote. */
+    PriceImprovement: {
+      factor: number;
+      maxVolumeFactor: number;
+      /** @description The best quote received. */
+      quote: components['schemas']['Quote'];
+    };
+    /** @description Defines the ways to calculate the protocol fee. */
+    FeePolicy:
+      | components['schemas']['Surplus']
+      | components['schemas']['Volume']
+      | components['schemas']['PriceImprovement'];
+    ExecutedProtocolFee: {
+      policy?: components['schemas']['FeePolicy'];
+      amount?: unknown & components['schemas']['TokenAmount'];
+      token?: unknown & components['schemas']['Address'];
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export type operations = Record<string, never>;

--- a/libs/repositories/src/index.ts
+++ b/libs/repositories/src/index.ts
@@ -43,6 +43,11 @@ export * from './repos/TokenHolderRepository/TokenHolderRepositoryFallback';
 export * from './repos/TokenHolderRepository/TokenHolderRepositoryGoldRush';
 export * from './repos/TokenHolderRepository/TokenHolderRepositoryMoralis';
 
+// User balance repositories
+export * from './repos/UserBalanceRepository/UserBalanceRepository';
+export * from './repos/UserBalanceRepository/UserBalanceRepositoryCache';
+export * from './repos/UserBalanceRepository/UserBalanceRepositoryViem';
+
 // Simulation repositories
 export * from './repos/SimulationRepository/SimulationRepository';
 export * from './repos/SimulationRepository/SimulationRepositoryTenderly';

--- a/libs/repositories/src/repos/UserBalanceRepository/UserBalanceRepository.ts
+++ b/libs/repositories/src/repos/UserBalanceRepository/UserBalanceRepository.ts
@@ -1,0 +1,20 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk';
+
+export const userBalanceRepositorySymbol = Symbol.for('UserBalanceRepository');
+
+export interface UserTokenBalance {
+  tokenAddress: string;
+  balance: string;
+  allowance: string;
+  decimals: number; // TODO: Maybe we don't need this. Read bellow
+  symbol?: string; // TODO: Unsure if we want to return this. Actually, I think instead we should use Erc20Repository to get the symbol, name, etc. (in the service layer). Leaving for now, since its nice for debugging. Hacking modeeeeeee!
+  name?: string; // TODO: Same as above
+}
+
+export interface UserBalanceRepository {
+  getUserTokenBalances(
+    chainId: SupportedChainId,
+    userAddress: string,
+    tokenAddresses: string[] // TODO: We could do a different repository that returns the list of tokens for our common lists. This way, the UI could just pass a list (which is highly cacheable) and a list of their additional tokens to this repository. But this repository is simpler, loads the tokens from a list of addresses
+  ): Promise<UserTokenBalance[]>;
+}

--- a/libs/repositories/src/repos/UserBalanceRepository/UserBalanceRepositoryCache.ts
+++ b/libs/repositories/src/repos/UserBalanceRepository/UserBalanceRepositoryCache.ts
@@ -1,0 +1,85 @@
+import { injectable } from 'inversify';
+import { SupportedChainId } from '@cowprotocol/cow-sdk';
+import { CacheRepository } from '../CacheRepository/CacheRepository';
+import {
+  UserBalanceRepository,
+  UserTokenBalance,
+} from './UserBalanceRepository';
+
+@injectable()
+export class UserBalanceRepositoryCache implements UserBalanceRepository {
+  constructor(
+    private userBalanceRepository: UserBalanceRepository,
+    private cacheRepository: CacheRepository,
+    private cachePrefix: string,
+    private cacheTimeSeconds: number
+  ) {}
+
+  private getCacheKey(
+    chainId: SupportedChainId,
+    userAddress: string,
+    tokenAddress?: string
+  ): string {
+    const baseKey = `${
+      this.cachePrefix
+    }:${chainId}:${userAddress.toLowerCase()}`;
+    if (tokenAddress) {
+      return `${baseKey}:${tokenAddress.toLowerCase()}`;
+    }
+    return baseKey;
+  }
+
+  async getUserTokenBalances(
+    chainId: SupportedChainId,
+    userAddress: string,
+    tokenAddresses: string[]
+  ): Promise<UserTokenBalance[]> {
+    const cacheKey = this.getCacheKey(chainId, userAddress);
+    const cached = await this.cacheRepository.get(cacheKey);
+
+    if (cached) {
+      try {
+        const cachedBalances: UserTokenBalance[] = JSON.parse(cached);
+        // Filter cached results to only include requested tokens
+        return cachedBalances.filter((balance) =>
+          tokenAddresses.some(
+            (addr) => addr.toLowerCase() === balance.tokenAddress.toLowerCase()
+          )
+        );
+      } catch (error) {
+        // If parsing fails, continue to fetch fresh data
+      }
+    }
+
+    const balances = await this.userBalanceRepository.getUserTokenBalances(
+      chainId,
+      userAddress,
+      tokenAddresses
+    );
+
+    // Cache the results
+    await this.cacheRepository.set(
+      cacheKey,
+      JSON.stringify(balances),
+      this.cacheTimeSeconds
+    );
+
+    return balances;
+  }
+
+  /**
+   * Invalidate a cache for a token
+   * @param chainId
+   * @param userAddress
+   * @param tokenAddress
+   */
+  async invalidateUserBalances(
+    chainId: SupportedChainId,
+    userAddress: string,
+    tokenAddress?: string
+  ): Promise<void> {
+    const cacheKey = this.getCacheKey(chainId, userAddress, tokenAddress);
+    // Invalidate using the TTL to zero
+    await this.cacheRepository.set(cacheKey, '', 0);
+  }
+}

--- a/libs/repositories/src/repos/UserBalanceRepository/UserBalanceRepositoryViem.ts
+++ b/libs/repositories/src/repos/UserBalanceRepository/UserBalanceRepositoryViem.ts
@@ -1,0 +1,98 @@
+import { injectable } from 'inversify';
+import {
+  COW_PROTOCOL_VAULT_RELAYER_ADDRESS,
+  SupportedChainId,
+} from '@cowprotocol/cow-sdk';
+import { erc20Abi, getAddress, PublicClient } from 'viem';
+
+import {
+  UserBalanceRepository,
+  UserTokenBalance,
+} from './UserBalanceRepository';
+
+@injectable()
+export class UserBalanceRepositoryViem implements UserBalanceRepository {
+  constructor(private viemClients: Record<SupportedChainId, PublicClient>) {}
+
+  async getUserTokenBalances(
+    chainId: SupportedChainId,
+    userAddress: string,
+    tokenAddresses: string[]
+  ): Promise<UserTokenBalance[]> {
+    const viemClient = this.viemClients[chainId];
+    const userAddressHex = getAddress(userAddress);
+    const vaultRelayerAddress = getAddress(
+      COW_PROTOCOL_VAULT_RELAYER_ADDRESS[chainId]
+    );
+
+    const contracts = tokenAddresses.flatMap((tokenAddress) => {
+      const tokenAddressHex = getAddress(tokenAddress);
+      return [
+        {
+          address: tokenAddressHex,
+          abi: erc20Abi,
+          functionName: 'balanceOf',
+          args: [userAddressHex],
+        },
+        {
+          address: tokenAddressHex,
+          abi: erc20Abi,
+          functionName: 'allowance',
+          args: [userAddressHex, vaultRelayerAddress],
+        },
+        {
+          address: tokenAddressHex,
+          abi: erc20Abi,
+          functionName: 'decimals', // TODO: Will remove and use ERC20Repository
+        },
+        {
+          address: tokenAddressHex,
+          abi: erc20Abi,
+          functionName: 'symbol', // TODO: Will remove and use ERC20Repository
+        },
+        {
+          address: tokenAddressHex,
+          abi: erc20Abi,
+          functionName: 'name', // TODO: Will remove and use ERC20Repository
+        },
+      ];
+    });
+
+    // TODO: We should probably have an alternative implementations using services that gets this information already for us like Moralis
+    // TODO: We need to batch the calls (it might be a loooong list of tokens)
+    const results = await viemClient.multicall({
+      contracts,
+    });
+
+    const balances: UserTokenBalance[] = [];
+
+    for (let i = 0; i < tokenAddresses.length; i++) {
+      const baseIndex = i * 5;
+      const balanceResult = results[baseIndex];
+      const allowanceResult = results[baseIndex + 1];
+      const decimalsResult = results[baseIndex + 2];
+      const symbolResult = results[baseIndex + 3];
+      const nameResult = results[baseIndex + 4];
+
+      // TODO: Improve the error handling. This implementation drops from the result tokens where the RPC fails, which can happen. It should re-attempt or/and return the errors
+      if (
+        balanceResult.status === 'success' &&
+        decimalsResult.status === 'success' &&
+        allowanceResult.status === 'success' &&
+        symbolResult.status === 'success' &&
+        nameResult.status === 'success'
+      ) {
+        balances.push({
+          tokenAddress: tokenAddresses[i],
+          balance: balanceResult.result.toString(),
+          allowance: allowanceResult.result.toString(),
+          decimals: Number(decimalsResult.result),
+          symbol: String(symbolResult.result),
+          name: String(nameResult.result),
+        });
+      }
+    }
+
+    return balances;
+  }
+}


### PR DESCRIPTION
This is the first PR of a series of PR to include: Live Balance and Allowance tracking using SSE  (see #157)

## Add balance repository
The goal is to define a minimalistic interface to load the balances and allowances.

The PR includes 2 implementations:
* `UserBalanceRepositoryViem`: Basic implementation in viem. Uses `multicall` to fetch all balances and allowances for the tokens using a simple RPC node.
* `UserBalanceRepositoryCache`: Adds a caching layer. This will use in-memory cache by default, or REDIS if setup (like we have currently in production)


## Todos and improvements
The PRs from this hackathon will document in #157 some TODOs I left behind. These should be straightforward to address later, but they were not the main focus during the hackathon.  

Specifically, this PR:  
- Skips loading `symbol`, `name`, and `decimals`. We already have an efficient cached repository (`ERC20Repository`) for this. For the hackathon, I added them directly to simplify things and avoid extra dependencies, but migrating to the repository will reduce unnecessary calls.  
- Adds batching limit support for the `multicall` to efficiently handle large token lists. A maximum batch size should be enforced to avoid oversized calls.  
- Introduces retry logic to improve resilience.  
- Improves error handling. Currently, balances that fail to load are simply dropped. A better approach would be to model the error and return it to the client if data can’t be delivered after retries.  
