### PR TITLE
feat: add tracking service

### DIFF
--- a/apps/api/src/app/inversify.config.ts
+++ b/apps/api/src/app/inversify.config.ts
@@ -5,6 +5,7 @@ import {
   getPushSubscriptionsRepository,
   getSimulationRepository,
   getTokenHolderRepository,
+  getUserBalanceRepository,
   getUsdRepository,
 } from '@cowprotocol/services';
 
@@ -15,6 +16,7 @@ import {
   PushSubscriptionsRepository,
   SimulationRepository,
   TokenHolderRepository,
+  UserBalanceRepository,
   UsdRepository,
   cacheRepositorySymbol,
   erc20RepositorySymbol,
@@ -22,19 +24,26 @@ import {
   pushSubscriptionsRepositorySymbol,
   tenderlyRepositorySymbol,
   tokenHolderRepositorySymbol,
+  userBalanceRepositorySymbol,
   usdRepositorySymbol,
 } from '@cowprotocol/repositories';
 
 import {
+  BalanceTrackingService,
+  BalanceTrackingServiceMain,
   SimulationService,
   SlippageService,
   SlippageServiceMain,
+  SSEService,
+  SSEServiceMain,
   TokenHolderService,
   TokenHolderServiceMain,
   UsdService,
   UsdServiceMain,
+  balanceTrackingServiceSymbol,
   simulationServiceSymbol,
   slippageServiceSymbol,
+  sseServiceSymbol,
   tokenHolderServiceSymbol,
   usdServiceSymbol,
 } from '@cowprotocol/services';
@@ -53,6 +62,7 @@ function getApiContainer(): Container {
   const erc20Repository = getErc20Repository(cacheRepository);
   const simulationRepository = getSimulationRepository();
   const tokenHolderRepository = getTokenHolderRepository(cacheRepository);
+  const userBalanceRepository = getUserBalanceRepository(cacheRepository);
   const usdRepository = getUsdRepository(cacheRepository, erc20Repository);
   const pushNotificationsRepository = getPushNotificationsRepository();
   const pushSubscriptionsRepository = getPushSubscriptionsRepository();
@@ -85,6 +95,10 @@ function getApiContainer(): Container {
     .bind<TokenHolderRepository>(tokenHolderRepositorySymbol)
     .toConstantValue(tokenHolderRepository);
 
+  apiContainer
+    .bind<UserBalanceRepository>(userBalanceRepositorySymbol)
+    .toConstantValue(userBalanceRepository);
+
   // Services
   apiContainer
     .bind<SlippageService>(slippageServiceSymbol)
@@ -99,6 +113,16 @@ function getApiContainer(): Container {
   apiContainer
     .bind<SimulationService>(simulationServiceSymbol)
     .to(SimulationService);
+
+  apiContainer
+    .bind<BalanceTrackingService>(balanceTrackingServiceSymbol)
+    .to(BalanceTrackingServiceMain)
+    .inSingletonScope();
+
+  apiContainer
+    .bind<SSEService>(sseServiceSymbol)
+    .to(SSEServiceMain)
+    .inSingletonScope();
 
   return apiContainer;
 }

--- a/libs/services/src/BalanceTrackingService/BalanceTrackingService.ts
+++ b/libs/services/src/BalanceTrackingService/BalanceTrackingService.ts
@@ -1,0 +1,73 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk';
+import { SSEClient } from '../SSEService/SSEService';
+
+export const balanceTrackingServiceSymbol = Symbol.for(
+  'BalanceTrackingService'
+);
+
+/**
+ * Balance or allowance change event
+ */
+export type BalanceAllowanceChangeEvent =
+  | BalanceChangeEvent
+  | AllowanceChangeEvent;
+
+export interface BalanceAllowanceChangeEventCommon {
+  chainId: SupportedChainId;
+  timestamp: number;
+  userAddress: string;
+  tokenAddress: string;
+}
+
+export interface BalanceChangeEvent extends BalanceAllowanceChangeEventCommon {
+  type: 'balance_change';
+  oldBalance: string;
+  newBalance: string;
+}
+
+export interface AllowanceChangeEvent
+  extends BalanceAllowanceChangeEventCommon {
+  type: 'allowance_change';
+  oldAllowance: string;
+  newAllowance: string;
+}
+
+export type BalanceChangeCallback = (
+  event: BalanceAllowanceChangeEvent
+) => void;
+
+export type BalanceTrackingRequest = Omit<SSEClient, 'send' | 'close'>;
+
+/**
+ * Service that keeps track of some user's balance and allowances, and notifies changes
+ */
+export interface BalanceTrackingService {
+  /**
+   * Starts tracking some user's balance and allowances for a list of tokens
+   * @param chainId
+   * @param userAddress
+   * @param tokenAddresses List of tokens to monitor
+   */
+  startTrackingUser(request: BalanceTrackingRequest): Promise<void>;
+
+  /**
+   * Stops tracking some user's balances and allowances
+   * @param chainId
+   * @param userAddress
+   */
+  stopTrackingUser(
+    chainId: SupportedChainId,
+    userAddress: string
+  ): Promise<void>;
+
+  /**
+   * Get all users being tracked
+   */
+  getTrackedUsers(): Promise<Array<BalanceTrackingRequest>>;
+
+  /**
+   * Event triggered when there's a change on balance or allowance for a tracked user
+   * @param callback
+   */
+  onBalanceChange(callback: BalanceChangeCallback): void;
+}

--- a/libs/services/src/BalanceTrackingService/BalanceTrackingServiceMain.ts
+++ b/libs/services/src/BalanceTrackingService/BalanceTrackingServiceMain.ts
@@ -1,0 +1,204 @@
+import { injectable, inject } from 'inversify';
+import { SupportedChainId } from '@cowprotocol/cow-sdk';
+import { logger } from '@cowprotocol/shared';
+import {
+  UserBalanceRepository,
+  UserTokenBalance,
+  userBalanceRepositorySymbol,
+} from '@cowprotocol/repositories';
+import {
+  BalanceTrackingService,
+  BalanceAllowanceChangeEvent,
+  BalanceChangeCallback,
+  BalanceTrackingRequest,
+} from './BalanceTrackingService';
+import { SSEService, sseServiceSymbol } from '../SSEService/SSEService';
+
+const POLLING_INTERVAL_MS = 5000; // 5 seconds // TODO: We should do this service more sophisticated. When a client subscribes, we poll more often, but because we want to use this is notifications, we might want to have other lower prio checking logics
+
+export interface TrackedUser extends BalanceTrackingRequest {
+  lastBalances: Map<string, UserTokenBalance>;
+  intervalId: NodeJS.Timeout;
+}
+
+@injectable()
+export class BalanceTrackingServiceMain implements BalanceTrackingService {
+  private trackedUsers = new Map<string, TrackedUser>();
+  private balanceChangeCallbacks: Array<BalanceChangeCallback> = [];
+
+  constructor(
+    @inject(userBalanceRepositorySymbol)
+    private userBalanceRepository: UserBalanceRepository,
+    @inject(sseServiceSymbol) private sseService?: SSEService
+  ) {
+    // Auto-connect to SSE service if available
+    if (this.sseService) {
+      const sseService = this.sseService;
+      this.onBalanceChange((event) => {
+        sseService.broadcastBalanceUpdate(event);
+      });
+    }
+  }
+
+  async startTrackingUser(request: BalanceTrackingRequest): Promise<void> {
+    const { clientId, chainId, tokenAddresses, userAddress } = request;
+    const key = this.getUserKey(chainId, userAddress);
+
+    // Stop existing tracking if any
+    await this.stopTrackingUser(chainId, userAddress);
+
+    // Get initial balances
+    // TODO: Maybe is not great that if this fails, the subscription is not done. This should be refined (hackathon mode)
+    const initialBalances =
+      await this.userBalanceRepository.getUserTokenBalances(
+        chainId,
+        userAddress,
+        tokenAddresses
+      );
+
+    const lastBalances = new Map<string, UserTokenBalance>();
+    initialBalances.forEach((balance) => {
+      lastBalances.set(balance.tokenAddress.toLowerCase(), balance);
+    });
+
+    if (this.sseService) {
+      this.sseService.broadcastInitialBalances(clientId, initialBalances);
+    }
+
+    // Start polling for changes
+    // TODO: This is too simplistic implementation. Ideally we don't do an interval per subscription, but instead we have a general periodic check that updates all subscriptions. For now, lets keep simple, but would be nice to refine.
+    const intervalId = setInterval(async () => {
+      try {
+        await this.checkBalanceChanges(
+          chainId,
+          userAddress,
+          tokenAddresses,
+          lastBalances
+        );
+      } catch (error) {
+        logger.error(
+          `[${intervalId}] Error checking balance changes for chainId=${chainId}, userAddress=${userAddress}, lastBalances=${lastBalances}:\n`,
+          error
+        );
+      }
+    }, POLLING_INTERVAL_MS);
+
+    this.trackedUsers.set(key, {
+      clientId,
+      chainId,
+      userAddress,
+      tokenAddresses,
+      lastBalances,
+      intervalId,
+    });
+
+    logger.info(
+      `Started tracking user ${userAddress} on chain ${chainId} for ${tokenAddresses.length} tokens. IntervalId=${intervalId}`
+    );
+  }
+
+  async stopTrackingUser(
+    chainId: SupportedChainId,
+    userAddress: string
+  ): Promise<void> {
+    const key = this.getUserKey(chainId, userAddress);
+    const trackedUser = this.trackedUsers.get(key);
+
+    if (trackedUser) {
+      clearInterval(trackedUser.intervalId);
+      this.trackedUsers.delete(key);
+      logger.info(`Stopped tracking user ${userAddress} on chain ${chainId}`);
+    }
+  }
+
+  async getTrackedUsers(): Promise<Array<BalanceTrackingRequest>> {
+    return Array.from(this.trackedUsers.values()).map(
+      ({ clientId, chainId, userAddress, tokenAddresses }) => ({
+        clientId,
+        chainId,
+        userAddress,
+        tokenAddresses,
+      })
+    );
+  }
+
+  onBalanceChange(callback: BalanceChangeCallback): void {
+    this.balanceChangeCallbacks.push(callback);
+  }
+
+  private async checkBalanceChanges(
+    chainId: SupportedChainId,
+    userAddress: string,
+    tokenAddresses: string[],
+    lastBalances: Map<string, UserTokenBalance>
+  ): Promise<void> {
+    const currentBalances =
+      await this.userBalanceRepository.getUserTokenBalances(
+        chainId,
+        userAddress,
+        tokenAddresses
+      );
+
+    for (const currentBalance of currentBalances) {
+      const tokenKey = currentBalance.tokenAddress.toLowerCase();
+      const lastBalance = lastBalances.get(tokenKey);
+
+      if (!lastBalance) {
+        // New token balance
+        lastBalances.set(tokenKey, currentBalance);
+        continue;
+      }
+
+      // Check for balance changes
+      if (lastBalance.balance !== currentBalance.balance) {
+        const event: BalanceAllowanceChangeEvent = {
+          type: 'balance_change',
+          chainId,
+          userAddress,
+          tokenAddress: currentBalance.tokenAddress,
+          oldBalance: lastBalance.balance,
+          newBalance: currentBalance.balance,
+          timestamp: Date.now(),
+        };
+
+        this.emitBalanceChange(event);
+      }
+
+      // Check for allowance changes (if both have allowance data)
+      if (
+        lastBalance.allowance &&
+        currentBalance.allowance &&
+        lastBalance.allowance !== currentBalance.allowance
+      ) {
+        const event: BalanceAllowanceChangeEvent = {
+          type: 'allowance_change',
+          chainId,
+          userAddress,
+          tokenAddress: currentBalance.tokenAddress,
+          oldAllowance: lastBalance.allowance,
+          newAllowance: currentBalance.allowance,
+          timestamp: Date.now(),
+        };
+
+        this.emitBalanceChange(event);
+      }
+
+      // Update the last known balance
+      lastBalances.set(tokenKey, currentBalance);
+    }
+  }
+
+  private emitBalanceChange(event: BalanceAllowanceChangeEvent): void {
+    this.balanceChangeCallbacks.forEach((callback) => {
+      try {
+        callback(event);
+      } catch (error) {
+        logger.error('Error in balance change callback:', error);
+      }
+    });
+  }
+
+  private getUserKey(chainId: SupportedChainId, userAddress: string): string {
+    return `${chainId}:${userAddress.toLowerCase()}`;
+  }
+}

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -11,4 +11,7 @@ export * from './SimulationService/SimulationService';
 export * from './SSEService/SSEService';
 export * from './SSEService/SSEServiceMain';
 
+export * from './BalanceTrackingService/BalanceTrackingService';
+export * from './BalanceTrackingService/BalanceTrackingServiceMain';
+
 export * from './factories';


### PR DESCRIPTION
This is the third PR of a series of PR to include: Live Balance and Allowance tracking using SSE  (see #157)

## Add balance tracking service
The goal is to define a service that manages start/stop tracking logic, delegates to the repository, and pushes updates via SSE  

The PR includes:
* `BalanceTrackingService`: Simple interface of the service. Defines relevant types, like the payload for balance/allowance change events . Also exposes `startTrackingUser` and `stopTrackingUser` to start monitoring the balance/allowance and do some actions when the balance changes (`onBalanceChange`).
* `BalanceTrackingServiceMain`: Implementation of the interface. It depends on the SSE Service (see #158) that can be optional injected. It also makes use of the balance repository (see #156) to fetch the balances and allowances. If the SSE service is injected, it will post the initial balance, and every update of balance, pushing them to the clients.

## Todos and improvements
The PRs from this hackathon will document in #157 some TODOs I left behind