### PR TITLE
fix: try to reconnect when rpc ws fails

### DIFF
--- a/libs/repositories/src/datasources/viem.ts
+++ b/libs/repositories/src/datasources/viem.ts
@@ -57,7 +57,11 @@ export function getViemClients(): Record<SupportedChainId, PublicClient> {
             default: defaultRpcUrls,
           },
         },
-        transport: defaultRpcUrls.webSocket ? webSocket() : http(),
+        transport: defaultRpcUrls.webSocket ? webSocket(undefined, {
+          retryDelay: 5_000, // 5sec
+          retryCount: 3,
+          reconnect: true,
+        }) : http(),
       });
 
       return acc;


### PR DESCRIPTION
The only errors I see in the BFF logs are related to viem rpc websocket connection error.
It only happens to Base and Polygon networks and happens every ~3 minutes.
I want to try to add `reconnect` to avoid frequent app restarts.

<img width="1251" height="484" alt="image" src="https://github.com/user-attachments/assets/b8db4797-8e3d-4b64-a4ba-ba89dc689022" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced stability of real-time connections by adding automatic retry (5-second backoff, up to 3 attempts) and auto-reconnect when using WebSocket transports. This reduces transient disconnects and improves consistency when networks are unstable. Existing HTTP behavior remains unchanged and continues to serve as a fallback when no WebSocket URL is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->