### PR TITLE
fix: socket proxy issues

### DIFF
--- a/apps/api/src/app/routes/proxies/socket/index.ts
+++ b/apps/api/src/app/routes/proxies/socket/index.ts
@@ -45,8 +45,8 @@ const proxy: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
     httpMethods: ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT'],
     replyOptions: {
       rewriteRequestHeaders: (request, headers) => ({
-        ...headers,
         'x-api-key': apiKey,
+        origin: 'https://swap.cow.fi',
       }),
     },
     preHandler: async (request) => {

--- a/apps/api/src/app/routes/proxies/socket/index.ts
+++ b/apps/api/src/app/routes/proxies/socket/index.ts
@@ -37,6 +37,8 @@ const proxy: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
 
   fastify.register(httpProxy, {
     upstream,
+    // The route file is mounted under '/proxies/socket', rewrite that prefix to '/'
+    rewritePrefix: '/',
     httpMethods: ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT'],
     replyOptions: {
       rewriteRequestHeaders: (request, headers) => ({

--- a/apps/api/src/app/routes/proxies/socket/index.ts
+++ b/apps/api/src/app/routes/proxies/socket/index.ts
@@ -50,8 +50,8 @@ const proxy: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
       }),
     },
     preHandler: async (request) => {
-      fastify.log.debug(
-        { url: request.url, method: request.method },
+      fastify.log.info(
+        { url: request.url, method: request.method, headers: request.headers },
         `Proxying request to socket ${upstream}`
       );
     },

--- a/apps/api/src/app/routes/proxies/socket/index.ts
+++ b/apps/api/src/app/routes/proxies/socket/index.ts
@@ -21,7 +21,10 @@ const proxy: FastifyPluginAsync = async (fastify, opts): Promise<void> => {
 
     reply
       .header('Access-Control-Allow-Origin', origin)
-      .header('Vary', 'Origin')
+      .header(
+        'Vary',
+        'Origin, Access-Control-Request-Method, Access-Control-Request-Headers'
+      )
       .header(
         'Access-Control-Allow-Methods',
         acrm || 'GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD'


### PR DESCRIPTION
# Summary

Fix socket proxy issues

# Testing

1. Running it locally, and calling the endpoint `http://localhost:8080/proxies/socket/api/v1/bungee-manual/dest-tokens?toChainId=137&includeBridges=across,cctp,gnosis-native-bridge&fromChainId=1`
2. Calling the bff barn endpoint `https://bff.barn.cow.fi/proxies/socket/api/v1/bungee-manual/dest-tokens?toChainId=137&includeBridges=across,cctp,gnosis-native-bridge&fromChainId=1`
3. Via https://github.com/cowprotocol/cowswap/pull/6292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CORS handling for the socket proxy to correctly vary responses for origin and preflight headers, reducing cross-origin errors.
  * Fixed path rewriting when proxying sockets so the mounted route prefix is stripped before forwarding, improving upstream compatibility.
  * Simplified forwarded headers to a single explicit origin to ensure consistent upstream behavior.

* **Chores**
  * Increased logging visibility for proxy requests (info level, includes request headers) and added clarifying comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->