### PR TITLE
ci(workflow): pin autodeploy action version 📌

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,7 +69,7 @@ jobs:
           # secrets: |
           #   id=npmrc,src=${{ github.workspace }}/.npmrc
 
-      - uses: cowprotocol/autodeploy-action@v2
+      - uses: cowprotocol/autodeploy-action@0c950eb2856af4f520a652b59e786bd349516480 # v2
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           images: ghcr.io/cowprotocol/bff/${{ env.PACKAGE_NAME }}:main


### PR DESCRIPTION
pins the autodeploy action to a specific commit sha, ensuring deterministic execution and preventing unexpected changes if the `v2` tag is updated. this improves workflow reliability and security.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure configuration to enhance stability and security by pinning action dependencies to specific verified versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->