### PR TITLE
fix: update sceme validation rules + tenderly types

### DIFF
--- a/apps/api/src/app/routes/__chainId/simulation/simulateBundle.ts
+++ b/apps/api/src/app/routes/__chainId/simulation/simulateBundle.ts
@@ -85,12 +85,12 @@ const successSchema = {
             original: {
               title: 'Original',
               description: 'Original value before the state change',
-              type: ['string', 'object', 'null'],
+              type: ['string', 'number', 'boolean', 'object', 'array', 'null'],
             },
             dirty: {
               title: 'Dirty',
               description: 'New value after the state change',
-              type: ['string', 'object', 'null'],
+              type: ['string', 'number', 'boolean', 'object', 'array', 'null'],
             },
             raw: {
               title: 'Raw Elements',

--- a/libs/repositories/src/gen/cow/cow-api-types.ts
+++ b/libs/repositories/src/gen/cow/cow-api-types.ts
@@ -481,6 +481,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/debug/simulation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Simulate an arbitrary order.
+         * @description Simulates an arbitrary order specified in the request body and returns the Tenderly simulation request, along with any simulation error if applicable.
+         *
+         */
+        post: operations["debugSimulationPost"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/debug/simulation/{uid}": {
         parameters: {
             query?: never;
@@ -1472,6 +1493,40 @@ export interface components {
             /** @description EIP-2930 access list for the transaction. */
             access_list?: components["schemas"]["AccessListItem"][];
         };
+        /** @description Request body for simulating an arbitrary order without it being stored in the orderbook.
+         *      */
+        SimulationRequest: {
+            /** @description The token being sold. */
+            sellToken: components["schemas"]["Address"];
+            /** @description The token being bought. */
+            buyToken: components["schemas"]["Address"];
+            /** @description Amount of sell token (hex- or decimal-encoded uint256). Must be greater than zero.
+             *      */
+            sellAmount: components["schemas"]["TokenAmount"];
+            /** @description Amount of buy token (hex- or decimal-encoded uint256). */
+            buyAmount: components["schemas"]["TokenAmount"];
+            /** @description Whether this is a sell or buy order. */
+            kind: components["schemas"]["OrderKind"];
+            /** @description The address of the order owner. */
+            owner: components["schemas"]["Address"];
+            /** @description The address that will receive the buy tokens. Defaults to the owner if omitted.
+             *      */
+            receiver?: components["schemas"]["Address"] | null;
+            /**
+             * @description Where the sell token should be drawn from.
+             * @default erc20
+             */
+            sellTokenBalance: components["schemas"]["SellTokenSource"];
+            /**
+             * @description Where the buy token should be transferred to.
+             * @default erc20
+             */
+            buyTokenBalance: components["schemas"]["BuyTokenDestination"];
+            /** @description Full app data JSON string. Defaults to `"{}"` if omitted.
+             *      */
+            appData?: string | null;
+            blockNumber?: number;
+        };
         /** @description The Tenderly simulation request for an order, along with any simulation error.
          *      */
         OrderSimulation: {
@@ -2437,9 +2492,67 @@ export interface operations {
             };
         };
     };
-    debugSimulation: {
+    debugSimulationPost: {
         parameters: {
             query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SimulationRequest"];
+            };
+        };
+        responses: {
+            /** @description Simulation request returned. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrderSimulation"];
+                };
+            };
+            /** @description Invalid JSON body, or `appData` is not valid JSON.
+             *      */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Order simulation endpoint is not enabled. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Request body failed schema validation: missing required field, wrong field type, zero `sellAmount`, or unrecognised `kind` value.
+             *      */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    debugSimulation: {
+        parameters: {
+            query?: {
+                /** @description Block number to simulate the order at. If not specified, the simulation uses the latest block.
+                 *      */
+                block_number?: number;
+            };
             header?: never;
             path: {
                 uid: components["schemas"]["UID"];
@@ -2457,7 +2570,8 @@ export interface operations {
                     "application/json": components["schemas"]["OrderSimulation"];
                 };
             };
-            /** @description Invalid order UID. */
+            /** @description Malformed path parameter (invalid order UID format) or invalid `block_number` query parameter.
+             *      */
             400: {
                 headers: {
                     [name: string]: unknown;

--- a/libs/repositories/src/repos/SimulationRepository/tenderlyTypes.ts
+++ b/libs/repositories/src/repos/SimulationRepository/tenderlyTypes.ts
@@ -578,8 +578,8 @@ interface LogRaw {
 export interface StateDiff {
   address: string;
   soltype: SoltypeElement | null;
-  original: string | Record<string, any> | null;
-  dirty: string | Record<string, any> | null;
+  original: string | number | boolean | Record<string, any> | unknown[] | null;
+  dirty: string | number | boolean | Record<string, any> | unknown[] | null;
   raw?: RawElement[];
 }
 

--- a/libs/repositories/src/utils/buildStateDiff.ts
+++ b/libs/repositories/src/utils/buildStateDiff.ts
@@ -134,7 +134,7 @@ function processRawOnlyDiff(
     if (!updated) {
       const newDiff: StateDiff = {
         address: diff.address,
-        soltype: diff.soltype || null,
+        soltype: diff.soltype ?? null,
         original: diff.original ?? null,
         dirty: diff.dirty ?? null,
         raw: [structuredClone<typeof rawElement>(rawElement)],

--- a/libs/repositories/src/utils/buildStateDiff.ts
+++ b/libs/repositories/src/utils/buildStateDiff.ts
@@ -135,8 +135,8 @@ function processRawOnlyDiff(
       const newDiff: StateDiff = {
         address: diff.address,
         soltype: diff.soltype || null,
-        original: diff.original || null,
-        dirty: diff.dirty || null,
+        original: diff.original ?? null,
+        dirty: diff.dirty ?? null,
         raw: [structuredClone<typeof rawElement>(rawElement)],
       };
 
@@ -153,7 +153,7 @@ function processSingleDiff(
   diff: StateDiff
 ): StateDiff[] {
   // Handle regular diffs (with complete soltype, original, dirty data)
-  if (diff?.soltype && diff?.original && diff?.dirty) {
+  if (diff?.soltype != null && diff?.original != null && diff?.dirty != null) {
     return processRegularDiff(accumulatedStateDiff, diff);
   }
   // Handle raw-only diffs (missing soltype, original, or dirty)

--- a/libs/repositories/src/utils/buildStateDiff.ts
+++ b/libs/repositories/src/utils/buildStateDiff.ts
@@ -153,6 +153,7 @@ function processSingleDiff(
   diff: StateDiff
 ): StateDiff[] {
   // Handle regular diffs (with complete soltype, original, dirty data)
+  // Using != null (loose check) intentionally to catch both null and undefined
   if (diff?.soltype != null && diff?.original != null && diff?.dirty != null) {
     return processRegularDiff(accumulatedStateDiff, diff);
   }


### PR DESCRIPTION
Tenderly simulation runs successfully, but when our BFF tries to serialize the response, Fastify's schema validation fails: The value of   '#/items/properties/stateDiff/items/properties/original' does not match schema definition  and it returns 500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simulation bundle endpoint now accepts numbers, booleans, and arrays for state-diff entries in addition to strings, objects, and nulls.

* **Bug Fixes**
  * Preserves falsy values (e.g., 0, false, empty arrays) when normalizing state diffs to avoid misclassifying valid values as missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->