### PR TITLE
feat(affiliate): include created_at in dune csv upload

### DIFF
--- a/libs/services/src/AffiliateProgramExportService/AffiliateProgramExportServiceImpl.ts
+++ b/libs/services/src/AffiliateProgramExportService/AffiliateProgramExportServiceImpl.ts
@@ -17,6 +17,7 @@ type AffiliateProgramRow = {
   revenue_split_affiliate_pct: number;
   revenue_split_trader_pct: number;
   revenue_split_dao_pct: number;
+  created_at: string;
   updated_at: string;
 };
 
@@ -64,6 +65,7 @@ export class AffiliateProgramExportServiceImpl
       revenue_split_affiliate_pct: affiliate.revenueSplitAffiliatePct,
       revenue_split_trader_pct: affiliate.revenueSplitTraderPct,
       revenue_split_dao_pct: affiliate.revenueSplitDaoPct,
+      created_at: affiliate.createdAt,
       updated_at: affiliate.updatedAt,
     }));
 
@@ -122,6 +124,7 @@ const CSV_HEADERS = [
   'revenue_split_affiliate_pct',
   'revenue_split_trader_pct',
   'revenue_split_dao_pct',
+  'created_at',
 ];
 
 function buildCsv(rows: AffiliateProgramRow[]): string {
@@ -138,6 +141,7 @@ function buildCsv(rows: AffiliateProgramRow[]): string {
       row.revenue_split_affiliate_pct,
       row.revenue_split_trader_pct,
       row.revenue_split_dao_pct,
+      row.created_at,
     ]
       .map(csvEscape)
       .join(',')


### PR DESCRIPTION
This is needed for the new Affiliate dashboard, as requested by Matias, to see affiliate code growth by day.

## To Test

1. Clone
2. Set `DUNE_AFFILIATE_PROGRAM_TABLE_NAME=affiliate_program_data_test`
3. Start the server
4. Check the column is present in the table

<img width="1890" height="1246" alt="image" src="https://github.com/user-attachments/assets/5717076a-c68f-4ce1-8dd1-c939127d48b9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Affiliate program exports now include creation timestamps, allowing users to track when each program was originally established.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->