### PR TITLE
fix(affiliate): dune caching & error repoting & linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,13 @@
 {
   "root": true,
   "ignorePatterns": ["**/*"],
-  "plugins": ["@nx"],
+  "extends": ["prettier"],
+  "plugins": ["@nx", "prettier"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {
+        "prettier/prettier": "warn",
         "@nx/enforce-module-boundaries": [
           "error",
           {
@@ -25,6 +27,12 @@
       "files": ["*.ts", "*.tsx"],
       "extends": ["plugin:@nx/typescript"],
       "rules": {}
+    },
+    {
+      "files": ["libs/repositories/src/gen/**/*.ts"],
+      "rules": {
+        "prettier/prettier": "off"
+      }
     },
     {
       "files": ["*.js", "*.jsx"],

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 # Add files here to ignore them from prettier formatting
 /dist
 /coverage
+/libs/repositories/src/gen

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,5 @@
 {
-  "singleQuote": true
+  "semi": false,
+  "singleQuote": true,
+  "printWidth": 120
 }

--- a/apps/api/src/app/inversify.config.spec.ts
+++ b/apps/api/src/app/inversify.config.spec.ts
@@ -1,0 +1,157 @@
+import 'reflect-metadata';
+import { decorate, injectable } from 'inversify';
+
+const symbol = (name: string): symbol => Symbol.for(name);
+const emptyObject = (): Record<string, never> => ({});
+const getter = () => jest.fn(emptyObject);
+
+const affiliateStatsServiceSymbol = symbol('AffiliateStatsService');
+const duneRepositorySymbol = symbol('DuneRepository');
+
+const getters = {
+  getAffiliatesRepository: getter(),
+  getCacheRepository: getter(),
+  getDuneRepository: jest.fn(() => ({ getQueryResults: jest.fn() })),
+  getErc20Repository: getter(),
+  getPushNotificationsRepository: getter(),
+  getPushSubscriptionsRepository: getter(),
+  getSimulationRepository: getter(),
+  getTokenBalancesRepository: getter(),
+  getTokenHolderRepository: getter(),
+  getUserBalanceRepository: getter(),
+  getUsdRepository: getter(),
+};
+
+const plainClasses = Object.fromEntries(
+  [
+    'AffiliatesRepository',
+    'AffiliateProgramExportService',
+    'AffiliateProgramExportServiceImpl',
+    'AffiliateStatsService',
+    'CacheRepository',
+    'DuneRepository',
+    'Erc20Repository',
+    'HooksService',
+    'HooksServiceImpl',
+    'Logger',
+    'PushNotificationsRepository',
+    'PushSubscriptionsRepository',
+    'SimulationRepository',
+    'SlippageService',
+    'SSEService',
+    'TokenBalancesRepository',
+    'TokenBalancesService',
+    'TokenDetailService',
+    'TokenHolderRepository',
+    'TokenHolderService',
+    'UsdRepository',
+    'UsdService',
+    'UserBalanceRepository',
+    'BalanceTrackingService',
+  ].map((name) => [name, class {}])
+);
+
+class InjectableStub {}
+decorate(injectable(), InjectableStub);
+
+class MockAffiliateStatsServiceImpl {
+  static instances: MockAffiliateStatsServiceImpl[] = [];
+
+  constructor(
+    public readonly duneRepository: unknown,
+    public readonly cacheTtlMs: number
+  ) {
+    MockAffiliateStatsServiceImpl.instances.push(this);
+  }
+}
+
+const symbols = {
+  affiliatesRepositorySymbol: symbol('AffiliatesRepository'),
+  affiliateProgramExportServiceSymbol: symbol('AffiliateProgramExportService'),
+  affiliateStatsServiceSymbol,
+  balanceTrackingServiceSymbol: symbol('BalanceTrackingService'),
+  cacheRepositorySymbol: symbol('CacheRepository'),
+  duneRepositorySymbol,
+  erc20RepositorySymbol: symbol('Erc20Repository'),
+  hooksServiceSymbol: symbol('HooksService'),
+  pushNotificationsRepositorySymbol: symbol('PushNotificationsRepository'),
+  pushSubscriptionsRepositorySymbol: symbol('PushSubscriptionsRepository'),
+  simulationServiceSymbol: symbol('SimulationService'),
+  slippageServiceSymbol: symbol('SlippageService'),
+  sseServiceSymbol: symbol('SSEService'),
+  tenderlyRepositorySymbol: symbol('SimulationRepository'),
+  tokenBalancesRepositorySymbol: symbol('TokenBalancesRepository'),
+  tokenBalancesServiceSymbol: symbol('TokenBalancesService'),
+  tokenDetailServiceSymbol: symbol('TokenDetailService'),
+  tokenHolderRepositorySymbol: symbol('TokenHolderRepository'),
+  tokenHolderServiceSymbol: symbol('TokenHolderService'),
+  usdRepositorySymbol: symbol('UsdRepository'),
+  usdServiceSymbol: symbol('UsdService'),
+  userBalanceRepositorySymbol: symbol('UserBalanceRepository'),
+};
+
+jest.mock('@cowprotocol/repositories', () => ({
+  ...plainClasses,
+  ...symbols,
+  ...getters,
+  isCmsEnabled: false,
+  isDuneEnabled: true,
+}));
+
+jest.mock('@cowprotocol/shared', () => ({
+  Logger: plainClasses.Logger,
+  logger: { warn: jest.fn() },
+}));
+
+jest.mock('@cowprotocol/services', () => ({
+  ...plainClasses,
+  ...symbols,
+  ...getters,
+  AffiliateStatsServiceImpl: MockAffiliateStatsServiceImpl,
+  BalanceTrackingServiceMain: InjectableStub,
+  SSEServiceMain: InjectableStub,
+  SimulationService: InjectableStub,
+  SlippageServiceMain: InjectableStub,
+  TokenBalancesServiceMain: InjectableStub,
+  TokenDetailServiceMain: InjectableStub,
+  TokenHolderServiceMain: InjectableStub,
+  UsdServiceMain: InjectableStub,
+}));
+
+describe('getApiContainer', () => {
+  const originalTtl = process.env.DUNE_AFFILIATE_STATS_CACHE_TTL_MS;
+
+  beforeEach(() => {
+    MockAffiliateStatsServiceImpl.instances = [];
+    process.env.DUNE_AFFILIATE_STATS_CACHE_TTL_MS = '1234';
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    if (originalTtl === undefined) {
+      delete process.env.DUNE_AFFILIATE_STATS_CACHE_TTL_MS;
+      return;
+    }
+
+    process.env.DUNE_AFFILIATE_STATS_CACHE_TTL_MS = originalTtl;
+  });
+
+  it('reuses the same affiliate stats service instance', async () => {
+    const { getApiContainer } = await import('./inversify.config');
+
+    const container = getApiContainer();
+    const first = container.get<MockAffiliateStatsServiceImpl>(
+      affiliateStatsServiceSymbol
+    );
+    const second = container.get<MockAffiliateStatsServiceImpl>(
+      affiliateStatsServiceSymbol
+    );
+
+    expect(first).toBe(second);
+    expect(MockAffiliateStatsServiceImpl.instances).toHaveLength(1);
+    expect(first.cacheTtlMs).toBe(1234);
+    expect(first.duneRepository).toBe(
+      getters.getDuneRepository.mock.results.at(-1)?.value
+    );
+  });
+});

--- a/apps/api/src/app/inversify.config.ts
+++ b/apps/api/src/app/inversify.config.ts
@@ -74,7 +74,7 @@ import {
 import { Container } from 'inversify';
 import { Logger, logger } from '@cowprotocol/shared';
 
-const DEFAULT_AFFILIATE_STATS_CACHE_TTL_MS = 3600000;
+const DEFAULT_AFFILIATE_STATS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 function getAffiliateStatsCacheTtlMs(): number {
   const rawValue = process.env.DUNE_AFFILIATE_STATS_CACHE_TTL_MS;
@@ -93,7 +93,7 @@ function getAffiliateStatsCacheTtlMs(): number {
   return parsed;
 }
 
-function getApiContainer(): Container {
+export function getApiContainer(): Container {
   const apiContainer = new Container();
 
   // Bind logger
@@ -163,7 +163,8 @@ function getApiContainer(): Container {
             duneRepository,
             affiliateStatsCacheTtlMs
           )
-      );
+      )
+      .inSingletonScope();
   }
 
   if (isDuneEnabled && isCmsEnabled) {

--- a/apps/api/src/app/routes/affiliate/affiliate-stats/_address/index.ts
+++ b/apps/api/src/app/routes/affiliate/affiliate-stats/_address/index.ts
@@ -54,7 +54,7 @@ const affiliateStats: FastifyPluginAsync = async (fastify): Promise<void> => {
           lastUpdatedAt: result.lastUpdatedAt,
         });
       } catch (error) {
-        fastify.log.error('Error fetching affiliate stats:', error);
+        fastify.log.error({ err: error }, 'Error fetching affiliate stats');
         return reply.status(500).send({ message: 'Unexpected error' });
       }
     }

--- a/apps/api/src/app/routes/affiliate/trader-stats/_address/index.ts
+++ b/apps/api/src/app/routes/affiliate/trader-stats/_address/index.ts
@@ -54,7 +54,7 @@ const traderStats: FastifyPluginAsync = async (fastify): Promise<void> => {
           lastUpdatedAt: result.lastUpdatedAt,
         });
       } catch (error) {
-        fastify.log.error('Error fetching affiliate trader stats:', error);
+        fastify.log.error({ err: error }, 'Error fetching affiliate trader stats');
         return reply.status(500).send({ message: 'Unexpected error' });
       }
     }

--- a/nx.json
+++ b/nx.json
@@ -34,7 +34,8 @@
       "inputs": [
         "default",
         "{workspaceRoot}/.eslintrc.json",
-        "{workspaceRoot}/.eslintignore"
+        "{workspaceRoot}/.eslintignore",
+        "{workspaceRoot}/.prettierrc"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cowprotocol/root",
+  "name": "cowswap-bff",
   "description": "Backend for frontend is a series of backend services and libraries that enhance user experience for the frontend",
   "version": "0.28.0",
   "license": "MIT",
@@ -17,6 +17,7 @@
     "build": "nx run-many --all --target=build",
     "test": "nx run-many --all --target=test",
     "lint": "nx run-many --all --target=lint",
+    "lint:fix": "nx run-many --all --target=lint --fix --skip-nx-cache",
     "new:fastify": "nx generate @nx/node:application --framework=fastify --docker --directory=apps",
     "new:node": "nx generate @nx/node:application --directory=apps --docker",
     "new:lib": "nx g @nx/node:library --directory=libs",
@@ -98,6 +99,7 @@
     "esbuild": "^0.17.17",
     "eslint": "~8.15.0",
     "eslint-config-prettier": "8.1.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "fastify-tsconfig": "^1.0.1",
     "jest": "^29.5.0",
     "jest-environment-node": "^29.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4875,6 +4875,13 @@ eslint-config-prettier@8.1.0:
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz"
   integrity sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==
 
+eslint-plugin-prettier@^4.2.1:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.5.tgz#91ca3f2f01a84f1272cce04e9717550494c0fe06"
+  integrity sha512-9Ni+xgemM2IWLq6aXEpP2+V/V30GeA/46Ar629vcMqVPodFFWC9skHu/D1phvuqtS8bJCFnNf01/qcmqYEwNfg==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
@@ -5129,6 +5136,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
+  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
 fast-glob@3.2.7:
   version "3.2.7"
@@ -8012,6 +8024,13 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz#6a31f88a4bad6c7adda253de12ba4edaea80ebcd"
+  integrity sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@^2.3.1, prettier@^2.6.2:
   version "2.8.8"


### PR DESCRIPTION
Please ignore the branch name.

## Summary
- The cache is not working right now because it was per request, to make it app wide we need `.inSingletonScope()`
- [Error reporting syntax was wrong making victoria logs less useful (missing error object)](https://victorialogs.dev.cow.fi/explore?schemaVersion=1&panes=%7B%22di2%22:%7B%22datasource%22:%22vm-auth-prod%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22victoriametrics-logs-datasource%22,%22uid%22:%22vm-auth-prod%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22level:contains_common_case%28%5C%22err%5C%22,%5C%22eror%5C%22,%5C%22error%5C%22%29%20%7C%20container:%20bff%2A%22,%22queryType%22:%22instant%22,%22maxLines%22:10%7D%5D,%22range%22:%7B%22from%22:%22now-12h%22,%22to%22:%22now%22%7D,%22panelsState%22:%7B%22logs%22:%7B%22columns%22:%7B%220%22:%22Time%22,%221%22:%22Line%22,%222%22:%22all%22%7D,%22visualisationType%22:%22table%22,%22labelFieldName%22:%22labels%22,%22refId%22:%22A%22%7D%7D,%22compact%22:false%7D%7D&orgId=1)
- Integrate prettier into eslint so that fixOnSave works in vs code
- PR with autofix https://github.com/cowprotocol/bff/pull/217

<img width="2961" height="760" alt="image" src="https://github.com/user-attachments/assets/9c5cbd49-bb58-4fb5-8ca5-750722639ce3" />

