### PR TITLE
feat(api): authorized origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,7 +78,8 @@
 #PROXY_ORIGIN=proxy-origin
 
 # Authorized domains
-# AUTHORIZED_ORIGINS=cow.fi
+# Exact hosts use the bare hostname; subdomains require a leading dot entry.
+# AUTHORIZED_ORIGINS=cow.fi,.cow.fi
 
 # GOLD RUSH
 # GOLD_RUSH_API_KEY=

--- a/apps/api/src/app/plugins/bffAuth.spec.ts
+++ b/apps/api/src/app/plugins/bffAuth.spec.ts
@@ -24,28 +24,46 @@ async function buildApp(authorizedOrigins?: string): Promise<FastifyInstance> {
   return app
 }
 
-function protectedRequest(app: FastifyInstance, origin?: string) {
-  return app.inject({
+function protectedRequest(app: FastifyInstance | undefined, origin?: string) {
+  return requireApp(app).inject({
     method: 'GET',
     url: '/proxies/test',
     headers: origin ? { origin } : undefined,
   })
 }
 
-function publicRequest(app: FastifyInstance, origin: string) {
-  return app.inject({
+function publicRequest(app: FastifyInstance | undefined, origin: string) {
+  return requireApp(app).inject({
     method: 'GET',
     url: '/public/test',
     headers: { origin },
   })
 }
 
+function requireApp(app: FastifyInstance | undefined): FastifyInstance {
+  if (!app) {
+    throw new Error('Fastify app was not initialized')
+  }
+  return app
+}
+
 describe('bffAuth', () => {
-  let app: FastifyInstance
+  let app: FastifyInstance | undefined
 
   afterEach(async () => {
     await app?.close()
+    app = undefined
     delete process.env.AUTHORIZED_ORIGINS
+  })
+
+  it('fails startup when AUTHORIZED_ORIGINS is set but contains no valid entries', () => {
+    process.env.AUTHORIZED_ORIGINS = ' , '
+
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./bffAuth')
+      })
+    }).toThrow('Malformed AUTHORIZED_ORIGINS: expected at least one hostname')
   })
 
   describe('when AUTHORIZED_ORIGINS is not set', () => {

--- a/apps/api/src/app/plugins/bffAuth.spec.ts
+++ b/apps/api/src/app/plugins/bffAuth.spec.ts
@@ -1,0 +1,216 @@
+import fastify, { FastifyInstance } from 'fastify'
+
+async function buildApp(authorizedOrigins?: string): Promise<FastifyInstance> {
+  if (authorizedOrigins !== undefined) {
+    process.env.AUTHORIZED_ORIGINS = authorizedOrigins
+  } else {
+    delete process.env.AUTHORIZED_ORIGINS
+  }
+
+  // Force re-evaluation of the AUTHORIZED_ORIGINS IIFE with the current env
+  let plugin: typeof import('./bffAuth') | undefined
+  jest.isolateModules(() => {
+    plugin = require('./bffAuth')
+  })
+  if (!plugin) {
+    throw new Error('bffAuth plugin failed to load')
+  }
+
+  const app = fastify()
+  await app.register(plugin.default)
+  app.get('/proxies/test', async () => ({ ok: true }))
+  app.get('/public/test', async () => ({ ok: true }))
+  await app.ready()
+  return app
+}
+
+function protectedRequest(app: FastifyInstance, origin?: string) {
+  return app.inject({
+    method: 'GET',
+    url: '/proxies/test',
+    headers: origin ? { origin } : undefined,
+  })
+}
+
+function publicRequest(app: FastifyInstance, origin: string) {
+  return app.inject({
+    method: 'GET',
+    url: '/public/test',
+    headers: { origin },
+  })
+}
+
+describe('bffAuth', () => {
+  let app: FastifyInstance
+
+  afterEach(async () => {
+    await app?.close()
+    delete process.env.AUTHORIZED_ORIGINS
+  })
+
+  describe('when AUTHORIZED_ORIGINS is not set', () => {
+    beforeEach(async () => {
+      app = await buildApp(undefined)
+    })
+
+    it('allows any origin on a protected path', async () => {
+      const res = await protectedRequest(app, 'https://attacker.com')
+      expect(res.statusCode).toBe(200)
+    })
+  })
+
+  describe('when AUTHORIZED_ORIGINS is set to cow.fi', () => {
+    beforeEach(async () => {
+      app = await buildApp('cow.fi')
+    })
+
+    it('blocks requests with no origin header', async () => {
+      const res = await protectedRequest(app)
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('allows localhost origins', async () => {
+      const res = await protectedRequest(app, 'http://localhost:3000')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('allows the exact root domain', async () => {
+      const res = await protectedRequest(app, 'https://cow.fi')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('blocks a direct subdomain unless a leading-dot entry is configured', async () => {
+      const res = await protectedRequest(app, 'https://swap.cow.fi')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('blocks a deeply nested subdomain unless a leading-dot entry is configured', async () => {
+      const res = await protectedRequest(app, 'https://staging.swap.cow.fi')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('blocks a domain that shares a suffix but is not a subdomain (evilcow.fi)', async () => {
+      const res = await protectedRequest(app, 'https://evilcow.fi')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('blocks an unauthorized domain entirely', async () => {
+      const res = await protectedRequest(app, 'https://attacker.com')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('blocks HTTP origins for remote domains', async () => {
+      const res = await protectedRequest(app, 'http://cow.fi')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('blocks origins with a non-default port', async () => {
+      const res = await protectedRequest(app, 'https://cow.fi:444')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('allows any origin on an unprotected path', async () => {
+      const res = await publicRequest(app, 'https://attacker.com')
+      expect(res.statusCode).toBe(200)
+    })
+  })
+
+  describe('when AUTHORIZED_ORIGINS is set to cow.fi,.cow.fi', () => {
+    beforeEach(async () => {
+      app = await buildApp('cow.fi,.cow.fi')
+    })
+
+    it('allows the exact root domain', async () => {
+      const res = await protectedRequest(app, 'https://cow.fi')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('allows a direct subdomain through the leading-dot entry', async () => {
+      const res = await protectedRequest(app, 'https://swap.cow.fi')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('allows a deeply nested subdomain through the leading-dot entry', async () => {
+      const res = await protectedRequest(app, 'https://staging.swap.cow.fi')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('blocks the leading-dot entry itself as a hostname', async () => {
+      const res = await protectedRequest(app, 'https://.cow.fi')
+      expect(res.statusCode).toBe(403)
+    })
+  })
+
+  describe('when AUTHORIZED_ORIGINS contains a specific subdomain (notevil.valid-domain.com)', () => {
+    beforeEach(async () => {
+      app = await buildApp('notevil.valid-domain.com')
+    })
+
+    it('allows the exact authorized subdomain', async () => {
+      const res = await protectedRequest(app, 'https://notevil.valid-domain.com')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('blocks sub-subdomains without a leading-dot entry', async () => {
+      const res = await protectedRequest(app, 'https://preview.notevil.valid-domain.com')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('blocks a domain that shares a suffix but is not a subdomain (evil-notevil.valid-domain.com)', async () => {
+      const res = await protectedRequest(app, 'https://evil-notevil.valid-domain.com')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('blocks the parent domain (valid-domain.com)', async () => {
+      const res = await protectedRequest(app, 'https://valid-domain.com')
+      expect(res.statusCode).toBe(403)
+    })
+  })
+
+  describe('when AUTHORIZED_ORIGINS contains a leading-dot entry (.notevil.valid-domain.com)', () => {
+    beforeEach(async () => {
+      app = await buildApp('.notevil.valid-domain.com')
+    })
+
+    it('allows subdomains of the leading-dot entry', async () => {
+      const res = await protectedRequest(app, 'https://preview.notevil.valid-domain.com')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('blocks the bare domain for the leading-dot entry', async () => {
+      const res = await protectedRequest(app, 'https://notevil.valid-domain.com')
+      expect(res.statusCode).toBe(403)
+    })
+  })
+
+  describe('when AUTHORIZED_ORIGINS contains multiple domains', () => {
+    beforeEach(async () => {
+      app = await buildApp('cow.fi,.cow.fi,swap-dev-5u6.pages.dev,.swap-dev-5u6.pages.dev')
+    })
+
+    it('allows an origin matching the first leading-dot entry', async () => {
+      const res = await protectedRequest(app, 'https://swap.cow.fi')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('allows an origin matching the exact pages.dev entry', async () => {
+      const res = await protectedRequest(app, 'https://swap-dev-5u6.pages.dev')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('allows a subdomain matching the pages.dev leading-dot entry', async () => {
+      const res = await protectedRequest(app, 'https://preview.swap-dev-5u6.pages.dev')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('blocks a suffix-squatting domain against the second entry (attacker-swap-dev-5u6.pages.dev)', async () => {
+      const res = await protectedRequest(app, 'https://attacker-swap-dev-5u6.pages.dev')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('blocks a domain that matches neither entry', async () => {
+      const res = await protectedRequest(app, 'https://attacker.com')
+      expect(res.statusCode).toBe(403)
+    })
+  })
+})

--- a/apps/api/src/app/plugins/bffAuth.spec.ts
+++ b/apps/api/src/app/plugins/bffAuth.spec.ts
@@ -66,6 +66,26 @@ describe('bffAuth', () => {
     }).toThrow('Malformed AUTHORIZED_ORIGINS: expected at least one hostname')
   })
 
+  it('fails startup in production when AUTHORIZED_ORIGINS is not set', () => {
+    const originalNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    delete process.env.AUTHORIZED_ORIGINS
+
+    try {
+      expect(() => {
+        jest.isolateModules(() => {
+          require('./bffAuth')
+        })
+      }).toThrow('Missing AUTHORIZED_ORIGINS in production')
+    } finally {
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = originalNodeEnv
+      }
+    }
+  })
+
   describe('when AUTHORIZED_ORIGINS is not set', () => {
     beforeEach(async () => {
       app = await buildApp(undefined)

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -9,7 +9,10 @@ const AUTHORIZED_ORIGINS = (() => {
     return []
   }
 
-  return domains.split(',').map((domain) => domain.trim())
+  return domains
+    .split(',')
+    .map((domain) => domain.trim().toLowerCase())
+    .filter(Boolean)
 })()
 
 export const bffAuth: FastifyPluginCallback = (fastify, opts, next) => {
@@ -26,7 +29,7 @@ export const bffAuth: FastifyPluginCallback = (fastify, opts, next) => {
       // Origin should be present
       !origin ||
       // The origin should be explicitly authorized
-      (!AUTHORIZED_ORIGINS.some((authorizedOrigin) => origin.endsWith(authorizedOrigin)) &&
+      (!isAuthorizedOrigin(origin) &&
         // Make an exception for localhost
         !isLocalhost(origin))
     ) {
@@ -45,6 +48,33 @@ function isLocalhost(origin: string): boolean {
     return false
   }
   return /^http:\/\/localhost:\d+\/?$/.test(origin)
+}
+
+function isAuthorizedOrigin(origin: string): boolean {
+  const url = parseOrigin(origin)
+  if (!url || url.protocol !== 'https:' || url.port) {
+    return false
+  }
+
+  const hostname = url.hostname.toLowerCase()
+
+  return AUTHORIZED_ORIGINS.some((authorizedOrigin) => isAuthorizedHostname(hostname, authorizedOrigin))
+}
+
+function isAuthorizedHostname(hostname: string, authorizedOrigin: string): boolean {
+  if (authorizedOrigin.startsWith('.')) {
+    return hostname.endsWith(authorizedOrigin) && hostname.length > authorizedOrigin.length
+  }
+
+  return hostname === authorizedOrigin
+}
+
+function parseOrigin(origin: string): URL | null {
+  try {
+    return new URL(origin)
+  } catch {
+    return null
+  }
 }
 
 export default fp(bffAuth, { fastify: '4.x', name: 'bffAuth' })

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -3,21 +3,11 @@ import { FastifyPluginCallback } from 'fastify'
 
 const PROTECTED_PATHS = ['/proxies']
 
-const AUTHORIZED_ORIGINS = (() => {
-  const domains = process.env.AUTHORIZED_ORIGINS
-  if (!domains) {
-    return []
-  }
-
-  return domains
-    .split(',')
-    .map((domain) => domain.trim().toLowerCase())
-    .filter(Boolean)
-})()
+const AUTHORIZED_ORIGINS = parseAuthorizedOrigins(process.env.AUTHORIZED_ORIGINS)
 
 export const bffAuth: FastifyPluginCallback = (fastify, opts, next) => {
   fastify.addHook('onRequest', async (request, reply) => {
-    // Return early if its an unprotected path
+    // Return early if auth is not configured or its an unprotected path
     if (AUTHORIZED_ORIGINS.length === 0 || !PROTECTED_PATHS.some((path) => request.url.startsWith(path))) {
       return
     }
@@ -48,6 +38,23 @@ function isLocalhost(origin: string): boolean {
     return false
   }
   return /^http:\/\/localhost:\d+\/?$/.test(origin)
+}
+
+function parseAuthorizedOrigins(domains: string | undefined): string[] {
+  if (domains === undefined) {
+    return []
+  }
+
+  const authorizedOrigins = domains
+    .split(',')
+    .map((domain) => domain.trim().toLowerCase())
+    .filter(Boolean)
+
+  if (authorizedOrigins.length === 0) {
+    throw new Error('Malformed AUTHORIZED_ORIGINS: expected at least one hostname')
+  }
+
+  return authorizedOrigins
 }
 
 function isAuthorizedOrigin(origin: string): boolean {

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -42,6 +42,9 @@ function isLocalhost(origin: string): boolean {
 
 function parseAuthorizedOrigins(domains: string | undefined): string[] {
   if (domains === undefined) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('Missing AUTHORIZED_ORIGINS in production')
+    }
     return []
   }
 

--- a/libs/repositories/src/datasources/coingecko.test.ts
+++ b/libs/repositories/src/datasources/coingecko.test.ts
@@ -26,9 +26,20 @@ describe('getCoingeckoProClient', () => {
   })
 
   it('should throw an error when COINGECKO_API_KEY is not set', () => {
-    expect(() => {
-      getCoingeckoProClient()
-    }).toThrow('COINGECKO_API_KEY is not set')
+    const originalApiKey = process.env.COINGECKO_API_KEY
+    delete process.env.COINGECKO_API_KEY
+
+    try {
+      expect(() => {
+        getCoingeckoProClient()
+      }).toThrow('COINGECKO_API_KEY is not set')
+    } finally {
+      if (originalApiKey === undefined) {
+        delete process.env.COINGECKO_API_KEY
+      } else {
+        process.env.COINGECKO_API_KEY = originalApiKey
+      }
+    }
   })
 
   it('should throw an error when COINGECKO_API_KEY is empty string', () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cowswap-bff",
   "description": "Backend for frontend is a series of backend services and libraries that enhance user experience for the frontend",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "license": "MIT",
   "scripts": {
     "start": "yarn start:api",


### PR DESCRIPTION
# Summary

Harden authorized origins.

Addresses feedback from https://github.com/cowprotocol/infrastructure/pull/5701

Note: in order to preserve current behaviour of accepting subdomains, BFF configs need to be updated from:

"cow.fi, cowswap.vercel.app, cowswap-dev.vercel.app, explorer-dev.vercel.app, swap-dev-5u6.pages.dev, explorer-dev-dxz.pages.dev"

to

".cow.fi, .cowswap.vercel.app, .cowswap-dev.vercel.app, .explorer-dev.vercel.app, .swap-dev-5u6.pages.dev, .explorer-dev-dxz.pages.dev"

# Testing

Unit tests




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened origin authorization by requiring HTTPS, rejecting origins with explicit ports, and tightening hostname matching (exact vs leading-dot subdomain rules).
  * Improved validation of `AUTHORIZED_ORIGINS`, including startup failures when it’s missing in production or malformed.

* **Tests**
  * Added/expanded coverage to verify authorization behavior across unset, single, wildcard, exact, and multi-entry origin configurations.

* **Documentation**
  * Updated `.env.example` guidance for `AUTHORIZED_ORIGINS` to clarify exact-host vs subdomain (leading-dot) matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->