### PR TITLE
feat: add vercel authorized origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,8 +78,8 @@
 #PROXY_ORIGIN=proxy-origin
 
 # Authorized domains
-# Exact hosts use the bare hostname; subdomains require a leading dot entry; Vercel previews use vercel:project:scope.
-# AUTHORIZED_ORIGINS=cow.fi,.cow.fi,vercel:swap-dev:cowswap-dev
+# Exact hosts use the bare hostname; subdomains require a leading dot entry; Vercel previews use vercel:branch-project:scope:build-project.
+# AUTHORIZED_ORIGINS=cow.fi,.cow.fi,vercel:swap-dev:cowswap-dev:swap
 
 # GOLD RUSH
 # GOLD_RUSH_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -78,8 +78,8 @@
 #PROXY_ORIGIN=proxy-origin
 
 # Authorized domains
-# Exact hosts use the bare hostname; subdomains require a leading dot entry.
-# AUTHORIZED_ORIGINS=cow.fi,.cow.fi
+# Exact hosts use the bare hostname; subdomains require a leading dot entry; Vercel previews use vercel:project:scope.
+# AUTHORIZED_ORIGINS=cow.fi,.cow.fi,vercel:swap-dev:cowswap-dev
 
 # GOLD RUSH
 # GOLD_RUSH_API_KEY=

--- a/apps/api/src/app/plugins/bffAuth.spec.ts
+++ b/apps/api/src/app/plugins/bffAuth.spec.ts
@@ -87,7 +87,7 @@ describe('bffAuth', () => {
   })
 
   it('fails startup when AUTHORIZED_ORIGINS contains a malformed Vercel entry', () => {
-    process.env.AUTHORIZED_ORIGINS = 'vercel:swap-dev'
+    process.env.AUTHORIZED_ORIGINS = 'vercel:swap-dev:cowswap-dev'
 
     expect(() => {
       jest.isolateModules(() => {
@@ -233,12 +233,22 @@ describe('bffAuth', () => {
 
   describe('when AUTHORIZED_ORIGINS contains a Vercel preview entry', () => {
     beforeEach(async () => {
-      app = await buildApp('vercel:swap-dev:cowswap-dev')
+      app = await buildApp('vercel:swap-dev:cowswap-dev:swap')
     })
 
     it('allows Vercel branch previews for the configured project and scope', async () => {
       const res = await protectedRequest(app, 'https://swap-dev-git-fix-widget-isolation-cowswap-dev.vercel.app')
       expect(res.statusCode).toBe(200)
+    })
+
+    it('allows Vercel build previews for the configured project and scope', async () => {
+      const res = await protectedRequest(app, 'https://swap-g5l4tofpk-cowswap-dev.vercel.app')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('blocks Vercel build previews with hyphenated build ids', async () => {
+      const res = await protectedRequest(app, 'https://swap-foo-bar-cowswap-dev.vercel.app')
+      expect(res.statusCode).toBe(403)
     })
 
     it('blocks Vercel branch previews for a different project in the same scope', async () => {

--- a/apps/api/src/app/plugins/bffAuth.spec.ts
+++ b/apps/api/src/app/plugins/bffAuth.spec.ts
@@ -86,6 +86,16 @@ describe('bffAuth', () => {
     }
   })
 
+  it('fails startup when AUTHORIZED_ORIGINS contains a malformed Vercel entry', () => {
+    process.env.AUTHORIZED_ORIGINS = 'vercel:swap-dev'
+
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./bffAuth')
+      })
+    }).toThrow('Malformed AUTHORIZED_ORIGINS: invalid Vercel entry')
+  })
+
   describe('when AUTHORIZED_ORIGINS is not set', () => {
     beforeEach(async () => {
       app = await buildApp(undefined)
@@ -217,6 +227,27 @@ describe('bffAuth', () => {
 
     it('blocks the bare domain for the leading-dot entry', async () => {
       const res = await protectedRequest(app, 'https://notevil.valid-domain.com')
+      expect(res.statusCode).toBe(403)
+    })
+  })
+
+  describe('when AUTHORIZED_ORIGINS contains a Vercel preview entry', () => {
+    beforeEach(async () => {
+      app = await buildApp('vercel:swap-dev:cowswap-dev')
+    })
+
+    it('allows Vercel branch previews for the configured project and scope', async () => {
+      const res = await protectedRequest(app, 'https://swap-dev-git-fix-widget-isolation-cowswap-dev.vercel.app')
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('blocks Vercel branch previews for a different project in the same scope', async () => {
+      const res = await protectedRequest(app, 'https://explorer-dev-git-fix-widget-isolation-cowswap-dev.vercel.app')
+      expect(res.statusCode).toBe(403)
+    })
+
+    it('blocks Vercel hosts with extra labels before vercel.app', async () => {
+      const res = await protectedRequest(app, 'https://swap-dev-git-fix.attacker-cowswap-dev.vercel.app')
       expect(res.statusCode).toBe(403)
     })
   })

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -2,6 +2,7 @@ import fp from 'fastify-plugin'
 import { FastifyPluginCallback } from 'fastify'
 
 const PROTECTED_PATHS = ['/proxies']
+const VERCEL_ORIGIN_PATTERN = /^vercel:([a-z0-9-]+):([a-z0-9-]+)$/
 
 const AUTHORIZED_ORIGINS = parseAuthorizedOrigins(process.env.AUTHORIZED_ORIGINS)
 
@@ -57,6 +58,10 @@ function parseAuthorizedOrigins(domains: string | undefined): string[] {
     throw new Error('Malformed AUTHORIZED_ORIGINS: expected at least one hostname')
   }
 
+  if (authorizedOrigins.some((origin) => origin.startsWith('vercel:') && !parseVercelEntry(origin))) {
+    throw new Error('Malformed AUTHORIZED_ORIGINS: invalid Vercel entry')
+  }
+
   return authorizedOrigins
 }
 
@@ -72,11 +77,43 @@ function isAuthorizedOrigin(origin: string): boolean {
 }
 
 function isAuthorizedHostname(hostname: string, authorizedOrigin: string): boolean {
+  const vercelEntry = parseVercelEntry(authorizedOrigin)
+  if (vercelEntry) {
+    return isAuthorizedVercelHostname(hostname, vercelEntry.project, vercelEntry.scope)
+  }
+
   if (authorizedOrigin.startsWith('.')) {
     return hostname.endsWith(authorizedOrigin) && hostname.length > authorizedOrigin.length
   }
 
   return hostname === authorizedOrigin
+}
+
+function isAuthorizedVercelHostname(hostname: string, project: string, scope: string): boolean {
+  const vercelSuffix = '.vercel.app'
+  if (!hostname.endsWith(vercelSuffix)) {
+    return false
+  }
+
+  const deployment = hostname.slice(0, -vercelSuffix.length)
+  const prefix = `${project}-git-`
+  const suffix = `-${scope}`
+
+  return (
+    !deployment.includes('.') &&
+    deployment.startsWith(prefix) &&
+    deployment.endsWith(suffix) &&
+    deployment.length > prefix.length + suffix.length
+  )
+}
+
+function parseVercelEntry(entry: string): { project: string; scope: string } | null {
+  const match = VERCEL_ORIGIN_PATTERN.exec(entry)
+  if (!match) {
+    return null
+  }
+
+  return { project: match[1], scope: match[2] }
 }
 
 function parseOrigin(origin: string): URL | null {

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -2,7 +2,7 @@ import fp from 'fastify-plugin'
 import { FastifyPluginCallback } from 'fastify'
 
 const PROTECTED_PATHS = ['/proxies']
-const VERCEL_ORIGIN_PATTERN = /^vercel:([a-z0-9-]+):([a-z0-9-]+)$/
+const VERCEL_ORIGIN_PATTERN = /^vercel:([a-z0-9-]+):([a-z0-9-]+):([a-z0-9-]+)$/
 
 const AUTHORIZED_ORIGINS = parseAuthorizedOrigins(process.env.AUTHORIZED_ORIGINS)
 
@@ -79,7 +79,7 @@ function isAuthorizedOrigin(origin: string): boolean {
 function isAuthorizedHostname(hostname: string, authorizedOrigin: string): boolean {
   const vercelEntry = parseVercelEntry(authorizedOrigin)
   if (vercelEntry) {
-    return isAuthorizedVercelHostname(hostname, vercelEntry.project, vercelEntry.scope)
+    return isAuthorizedVercelHostname(hostname, vercelEntry.branchProject, vercelEntry.scope, vercelEntry.buildProject)
   }
 
   if (authorizedOrigin.startsWith('.')) {
@@ -89,31 +89,41 @@ function isAuthorizedHostname(hostname: string, authorizedOrigin: string): boole
   return hostname === authorizedOrigin
 }
 
-function isAuthorizedVercelHostname(hostname: string, project: string, scope: string): boolean {
+function isAuthorizedVercelHostname(
+  hostname: string,
+  branchProject: string,
+  scope: string,
+  buildProject: string
+): boolean {
   const vercelSuffix = '.vercel.app'
   if (!hostname.endsWith(vercelSuffix)) {
     return false
   }
 
   const deployment = hostname.slice(0, -vercelSuffix.length)
-  const prefix = `${project}-git-`
+  const branchPrefix = `${branchProject}-git-`
+  const buildPrefix = `${buildProject}-`
   const suffix = `-${scope}`
 
-  return (
-    !deployment.includes('.') &&
-    deployment.startsWith(prefix) &&
-    deployment.endsWith(suffix) &&
-    deployment.length > prefix.length + suffix.length
-  )
+  if (deployment.includes('.') || !deployment.endsWith(suffix)) {
+    return false
+  }
+
+  if (deployment.startsWith(branchPrefix)) {
+    return deployment.length > branchPrefix.length + suffix.length
+  }
+
+  const buildId = deployment.slice(buildPrefix.length, -suffix.length)
+  return deployment.startsWith(buildPrefix) && /^[a-z0-9]+$/.test(buildId)
 }
 
-function parseVercelEntry(entry: string): { project: string; scope: string } | null {
+function parseVercelEntry(entry: string): { branchProject: string; scope: string; buildProject: string } | null {
   const match = VERCEL_ORIGIN_PATTERN.exec(entry)
   if (!match) {
     return null
   }
 
-  return { project: match[1], scope: match[2] }
+  return { branchProject: match[1], scope: match[2], buildProject: match[3] }
 }
 
 function parseOrigin(origin: string): URL | null {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cowswap-bff",
   "description": "Backend for frontend is a series of backend services and libraries that enhance user experience for the frontend",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "license": "MIT",
   "scripts": {
     "start": "yarn start:api",


### PR DESCRIPTION
# Summary

Adding a notation specific for vercel previews, so we avoid allow-listing the whole subdomain `.vercel.app`.
Example: `AUTHORIZED_ORIGINS=vercel:swap-dev:cowswap-dev:swap` for allowing `https://swap-dev-git-fix-widget-isolation-cowswap-dev.vercel.app` or `https://swap-g5l4tofpk-cowswap-dev.vercel.app`.

# Testing

Unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Vercel preview deployment hostnames in `AUTHORIZED_ORIGINS`, including branch and build hostname validation by project and scope.

* **Bug Fixes**
  * Misconfigured `AUTHORIZED_ORIGINS` Vercel entries now fail at startup with a clear “Malformed …” error.
  * Improved hostname checks for Vercel previews to prevent unintended authorization.

* **Documentation**
  * Updated `.env.example` to document the exact `AUTHORIZED_ORIGINS` Vercel format and provide a commented preview deployment example.

* **Tests**
  * Expanded coverage for valid and invalid Vercel `AUTHORIZED_ORIGINS` scenarios.

* **Chores**
  * Bumped version to `0.31.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->