### PR TITLE
fix: support vercel path truncation when branch name is long

### DIFF
--- a/apps/api/src/app/plugins/bffAuth.spec.ts
+++ b/apps/api/src/app/plugins/bffAuth.spec.ts
@@ -246,6 +246,12 @@ describe('bffAuth', () => {
       expect(res.statusCode).toBe(200)
     })
 
+    it('allows max-length Vercel branch previews with a truncated scope suffix', async () => {
+      const branch = 'a'.repeat(50)
+      const res = await protectedRequest(app, `https://swap-dev-git-${branch}.vercel.app`)
+      expect(res.statusCode).toBe(200)
+    })
+
     it('blocks Vercel build previews with hyphenated build ids', async () => {
       const res = await protectedRequest(app, 'https://swap-foo-bar-cowswap-dev.vercel.app')
       expect(res.statusCode).toBe(403)
@@ -259,6 +265,20 @@ describe('bffAuth', () => {
     it('blocks Vercel hosts with extra labels before vercel.app', async () => {
       const res = await protectedRequest(app, 'https://swap-dev-git-fix.attacker-cowswap-dev.vercel.app')
       expect(res.statusCode).toBe(403)
+    })
+  })
+
+  describe('when AUTHORIZED_ORIGINS contains a Vercel preview entry with a long build project', () => {
+    beforeEach(async () => {
+      app = await buildApp('vercel:swap-dev:cowswap-dev:very-long-build-project-name-that-pushes-labels')
+    })
+
+    it('allows max-length Vercel build previews with a truncated scope suffix', async () => {
+      const res = await protectedRequest(
+        app,
+        'https://very-long-build-project-name-that-pushes-labels-g5l4tofpk-cowsw.vercel.app'
+      )
+      expect(res.statusCode).toBe(200)
     })
   })
 

--- a/apps/api/src/app/plugins/bffAuth.spec.ts
+++ b/apps/api/src/app/plugins/bffAuth.spec.ts
@@ -246,10 +246,10 @@ describe('bffAuth', () => {
       expect(res.statusCode).toBe(200)
     })
 
-    it('allows max-length Vercel branch previews with a truncated scope suffix', async () => {
+    it('blocks max-length Vercel branch previews with only a fake scope fragment in the branch name', async () => {
       const branch = 'a'.repeat(48)
       const res = await protectedRequest(app, `https://swap-dev-git-${branch}-c.vercel.app`)
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(403)
     })
 
     it('blocks max-length Vercel branch previews without a scope fragment', async () => {

--- a/apps/api/src/app/plugins/bffAuth.spec.ts
+++ b/apps/api/src/app/plugins/bffAuth.spec.ts
@@ -247,9 +247,15 @@ describe('bffAuth', () => {
     })
 
     it('allows max-length Vercel branch previews with a truncated scope suffix', async () => {
+      const branch = 'a'.repeat(48)
+      const res = await protectedRequest(app, `https://swap-dev-git-${branch}-c.vercel.app`)
+      expect(res.statusCode).toBe(200)
+    })
+
+    it('blocks max-length Vercel branch previews without a scope fragment', async () => {
       const branch = 'a'.repeat(50)
       const res = await protectedRequest(app, `https://swap-dev-git-${branch}.vercel.app`)
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(403)
     })
 
     it('blocks Vercel build previews with hyphenated build ids', async () => {
@@ -279,6 +285,14 @@ describe('bffAuth', () => {
         'https://very-long-build-project-name-that-pushes-labels-g5l4tofpk-cowsw.vercel.app'
       )
       expect(res.statusCode).toBe(200)
+    })
+
+    it('blocks max-length Vercel build previews without a scope fragment', async () => {
+      const res = await protectedRequest(
+        app,
+        'https://very-long-build-project-name-that-pushes-labels-g5l4tofpkabc123.vercel.app'
+      )
+      expect(res.statusCode).toBe(403)
     })
   })
 

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -107,15 +107,6 @@ function isAuthorizedVercelHostname(
   const suffix = `-${scope}`
   const hasFullSuffix = deployment.endsWith(suffix)
   const maxDeploymentLabelLength = 63
-  let truncatedScopeFragmentLength = 0
-
-  if (!hasFullSuffix) {
-    for (let length = 2; length < suffix.length; length++) {
-      if (deployment.endsWith(suffix.slice(0, length))) {
-        truncatedScopeFragmentLength = length
-      }
-    }
-  }
 
   if (
     // It shouldn't have additional subdomains
@@ -129,10 +120,8 @@ function isAuthorizedVercelHostname(
   }
 
   if (deployment.startsWith(branchPrefix)) {
-    // Branch previews need branch text before the optional scope suffix
-    return hasFullSuffix
-      ? deployment.length > branchPrefix.length + suffix.length
-      : truncatedScopeFragmentLength > 0 && deployment.length > branchPrefix.length + truncatedScopeFragmentLength
+    // Truncated branch labels cannot prove the suffix is not part of the branch name
+    return hasFullSuffix && deployment.length > branchPrefix.length + suffix.length
   }
 
   if (!deployment.startsWith(buildPrefix)) {

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -107,6 +107,15 @@ function isAuthorizedVercelHostname(
   const suffix = `-${scope}`
   const hasFullSuffix = deployment.endsWith(suffix)
   const maxDeploymentLabelLength = 63
+  let truncatedScopeFragmentLength = 0
+
+  if (!hasFullSuffix) {
+    for (let length = 2; length < suffix.length; length++) {
+      if (deployment.endsWith(suffix.slice(0, length))) {
+        truncatedScopeFragmentLength = length
+      }
+    }
+  }
 
   if (
     // It shouldn't have additional subdomains
@@ -121,7 +130,9 @@ function isAuthorizedVercelHostname(
 
   if (deployment.startsWith(branchPrefix)) {
     // Branch previews need branch text before the optional scope suffix
-    return deployment.length > branchPrefix.length + (hasFullSuffix ? suffix.length : 0)
+    return hasFullSuffix
+      ? deployment.length > branchPrefix.length + suffix.length
+      : truncatedScopeFragmentLength > 0 && deployment.length > branchPrefix.length + truncatedScopeFragmentLength
   }
 
   if (!deployment.startsWith(buildPrefix)) {
@@ -142,7 +153,7 @@ function isAuthorizedVercelHostname(
   const suffixFragment = buildPart.slice(buildId.length)
 
   // Truncated build labels may keep only the start of "-scope"
-  return /^[a-z0-9]+$/.test(buildId) && suffix.startsWith(suffixFragment)
+  return /^[a-z0-9]+$/.test(buildId) && suffixFragment.length > 1 && suffix.startsWith(suffixFragment)
 }
 
 function parseVercelEntry(entry: string): { branchProject: string; scope: string; buildProject: string } | null {

--- a/apps/api/src/app/plugins/bffAuth.ts
+++ b/apps/api/src/app/plugins/bffAuth.ts
@@ -8,7 +8,7 @@ const AUTHORIZED_ORIGINS = parseAuthorizedOrigins(process.env.AUTHORIZED_ORIGINS
 
 export const bffAuth: FastifyPluginCallback = (fastify, opts, next) => {
   fastify.addHook('onRequest', async (request, reply) => {
-    // Return early if auth is not configured or its an unprotected path
+    // Return early if auth is not configured or it's an unprotected path
     if (AUTHORIZED_ORIGINS.length === 0 || !PROTECTED_PATHS.some((path) => request.url.startsWith(path))) {
       return
     }
@@ -97,6 +97,7 @@ function isAuthorizedVercelHostname(
 ): boolean {
   const vercelSuffix = '.vercel.app'
   if (!hostname.endsWith(vercelSuffix)) {
+    // Only Vercel preview hosts use this suffix
     return false
   }
 
@@ -104,17 +105,44 @@ function isAuthorizedVercelHostname(
   const branchPrefix = `${branchProject}-git-`
   const buildPrefix = `${buildProject}-`
   const suffix = `-${scope}`
+  const hasFullSuffix = deployment.endsWith(suffix)
+  const maxDeploymentLabelLength = 63
 
-  if (deployment.includes('.') || !deployment.endsWith(suffix)) {
+  if (
+    // It shouldn't have additional subdomains
+    deployment.includes('.') ||
+    // It shouldn't exceed the DNS label limit
+    deployment.length > maxDeploymentLabelLength ||
+    // Missing full suffix is only valid when Vercel hit the DNS label limit
+    (!hasFullSuffix && deployment.length !== maxDeploymentLabelLength)
+  ) {
     return false
   }
 
   if (deployment.startsWith(branchPrefix)) {
-    return deployment.length > branchPrefix.length + suffix.length
+    // Branch previews need branch text before the optional scope suffix
+    return deployment.length > branchPrefix.length + (hasFullSuffix ? suffix.length : 0)
   }
 
-  const buildId = deployment.slice(buildPrefix.length, -suffix.length)
-  return deployment.startsWith(buildPrefix) && /^[a-z0-9]+$/.test(buildId)
+  if (!deployment.startsWith(buildPrefix)) {
+    // Anything else is not a configured build preview
+    return false
+  }
+
+  const buildPart = hasFullSuffix
+    ? deployment.slice(buildPrefix.length, -suffix.length)
+    : deployment.slice(buildPrefix.length)
+
+  if (hasFullSuffix) {
+    // Full labels keep the original strict build-id check
+    return /^[a-z0-9]+$/.test(buildPart)
+  }
+
+  const buildId = buildPart.split('-', 1)[0]
+  const suffixFragment = buildPart.slice(buildId.length)
+
+  // Truncated build labels may keep only the start of "-scope"
+  return /^[a-z0-9]+$/.test(buildId) && suffix.startsWith(suffixFragment)
 }
 
 function parseVercelEntry(entry: string): { branchProject: string; scope: string; buildProject: string } | null {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cowswap-bff",
   "description": "Backend for frontend is a series of backend services and libraries that enhance user experience for the frontend",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "license": "MIT",
   "scripts": {
     "start": "yarn start:api",


### PR DESCRIPTION
# Summary

Addresses https://github.com/cowprotocol/bff/pull/223#discussion_r3513512141

# Testing

Unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authorization validation for Vercel preview hostnames, including correct handling of maximum-length cases.
  * Improved rules for distinguishing full versus truncated scope fragments for both branch and build preview hostnames.
* **Tests**
  * Added more test coverage for maximum-length Vercel branch and build preview hostnames, including truncated-scope scenarios.
* **Chores**
  * Bumped the app version to the next patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->