### PR TITLE
deps: consolidate Renovate GitHub Actions updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
         run: yarn test --ci --coverage
 
       - name: Upload test results and coverage
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
@@ -60,7 +60,7 @@ jobs:
         run: npx nx affected --target=test --base=origin/main --ci --coverage
 
       - name: Upload affected results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: affected-results

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
           - apps/telegram
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -35,10 +35,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: setup-buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -49,12 +49,12 @@ jobs:
 
       - name: 'Image metadata for ${{ env.PACKAGE_NAME }}'
         id: image_meta
-        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}/${{ env.PACKAGE_NAME }}
 
       - name: 'BFF: Build and push ${{ env.PACKAGE_NAME }}'
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ${{ matrix.package }}/Dockerfile


### PR DESCRIPTION
## Summary

Consolidates six Renovate PRs into a single update to avoid merge conflicts on overlapping workflow files:

- #226 — `actions/checkout` v5 → v7
- #228 — `actions/upload-artifact` v4 → v7
- #230 — `docker/build-push-action` v6 → v7
- #231 — `docker/login-action` v3 → v4
- #232 — `docker/metadata-action` v5 → v6
- #233 — `docker/setup-buildx-action` v3 → v4

All versions are pinned to full commit SHAs per [`.github/renovate.json5`](.github/renovate.json5).

## Local verification

- `yarn lint` — pass
- `yarn test` — pass
- `yarn build` — pass

## Test plan

- [x] CI: Test and Lint Affected Projects
- [x] CI: Docker build matrix (api, twap, notification-producer, telegram)
- [x] Socket Security checks
- [x] Close superseded Renovate PRs (#226, #228, #230–#233) after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing and linting workflows to use newer action versions.
  * Updated Docker image build and publishing workflows for improved action support.
  * Existing build, test, packaging, and publishing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->