### PR TITLE
fix(notification-producer): logging, Solana bump, address casing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,9 @@
 # Producer networks: Comma-separated list of chain IDs to run the notification producer on
 #NOTIFICATIONS_PRODUCER_CHAINS=1,100
 
+# CoW Protocol environment used by the trade notification producer to pick the settlement contract to watch: 'prod' or 'staging'. Defaults to 'staging'.
+COW_PROTOCOL_ENV=staging
+
 #DUNE_API_KEY=
 #DUNE_QUERY_ID_TRADER_STATS=
 #DUNE_QUERY_ID_TRADER_ACTIVITY=

--- a/apps/notification-producer/src/main.ts
+++ b/apps/notification-producer/src/main.ts
@@ -14,10 +14,9 @@ import {
 import { Runnable } from '../types'
 import { TradeNotificationProducer } from './producers/trade/TradeNotificationProducer'
 import { ExpiredOrdersNotificationProducer } from './producers/expired-orders/ExpiredOrdersNotificationProducer'
-import { ALL_SUPPORTED_CHAIN_IDS } from '@cowprotocol/cow-sdk'
 import ms from 'ms'
 import { CmsNotificationProducer } from './producers/cms/CmsNotificationProducer'
-import { logger } from '@cowprotocol/shared'
+import { AllChainIds, logger } from '@cowprotocol/shared'
 
 const TIMEOUT_STOP_PRODUCERS = ms(`30s`)
 
@@ -97,10 +96,10 @@ function getProducerChains() {
 
   // If no producer networks are specified, use all supported chain ids
   if (producerNetworks.length === 0) {
-    return ALL_SUPPORTED_CHAIN_IDS
+    return AllChainIds
   }
 
-  return ALL_SUPPORTED_CHAIN_IDS.filter((chain) => producerNetworks.includes(chain))
+  return AllChainIds.filter((chain) => producerNetworks.includes(chain))
 }
 async function gracefulShutdown(producers: Runnable[], producersPromise: Promise<void[]>) {
   if (shuttingDown) return

--- a/apps/notification-producer/src/main.ts
+++ b/apps/notification-producer/src/main.ts
@@ -16,7 +16,7 @@ import { TradeNotificationProducer } from './producers/trade/TradeNotificationPr
 import { ExpiredOrdersNotificationProducer } from './producers/expired-orders/ExpiredOrdersNotificationProducer'
 import ms from 'ms'
 import { CmsNotificationProducer } from './producers/cms/CmsNotificationProducer'
-import { AllChainIds, logger } from '@cowprotocol/shared'
+import { EVM_CHAIN_IDS, logger } from '@cowprotocol/shared'
 
 const TIMEOUT_STOP_PRODUCERS = ms(`30s`)
 
@@ -94,12 +94,13 @@ function getProducerChains() {
   const producerNetworks =
     process.env.NOTIFICATIONS_PRODUCER_CHAINS?.split(',').map((chain) => Number(chain.trim())) || []
 
-  // If no producer networks are specified, use all supported chain ids
+  // Notification producers need an RPC client and on-chain settlement contracts, so only EVM chains
+  // apply here (Solana is supported elsewhere in the repo, e.g. USD prices, just not by this app).
   if (producerNetworks.length === 0) {
-    return AllChainIds
+    return EVM_CHAIN_IDS
   }
 
-  return AllChainIds.filter((chain) => producerNetworks.includes(chain))
+  return EVM_CHAIN_IDS.filter((chain) => producerNetworks.includes(chain))
 }
 async function gracefulShutdown(producers: Runnable[], producersPromise: Promise<void[]>) {
   if (shuttingDown) return

--- a/apps/notification-producer/src/producers/cms/CmsNotificationProducer.ts
+++ b/apps/notification-producer/src/producers/cms/CmsNotificationProducer.ts
@@ -53,18 +53,34 @@ export class CmsNotificationProducer implements Runnable {
   }
 
   async fetchAndSend(): Promise<void> {
-    const accounts = await this.props.pushSubscriptionsRepository.getAllSubscribedAccounts()
+    const accounts = (await this.props.pushSubscriptionsRepository.getAllSubscribedAccounts()).map(account => account.toLowerCase())
+    logger.debug(
+      `[CmsNotificationProducer] Watching ${accounts.length} subscribed account(s): ${JSON.stringify(accounts)}`
+    )
 
     // Get PUSH notifications
-    const cmsPushNotifications = (await this.props.pushSubscriptionsRepository.getPushNotifications()).filter(
+    const allCmsPushNotifications = await this.props.pushSubscriptionsRepository.getPushNotifications()
+    logger.debug(`[CmsNotificationProducer] CMS returned ${allCmsPushNotifications.length} push notification(s)`)
+
+    const cmsPushNotifications = allCmsPushNotifications.filter(
       // Include only the notifications for subscribed accounts
-      ({ account }) => accounts.includes(account)
+      ({ account }) => accounts.includes(account.toLowerCase())
+    )
+    logger.debug(
+      `[CmsNotificationProducer] ${cmsPushNotifications.length} of ${allCmsPushNotifications.length} CMS notification(s) match a subscribed account`
     )
 
     const pendingNotifications = Array.from(this.pendingNotifications.values())
+    if (pendingNotifications.length > 0) {
+      logger.debug(
+        `[CmsNotificationProducer] ${pendingNotifications.length} pending notification(s) from a previous failed send`
+      )
+    }
+
     const pushNotifications = cmsPushNotifications.map(fromCmsToNotifications).concat(pendingNotifications)
 
     if (pushNotifications.length === 0) {
+      logger.debug(`[CmsNotificationProducer] No notifications to send`)
       return
     }
 
@@ -74,9 +90,11 @@ export class CmsNotificationProducer implements Runnable {
     pushNotifications.forEach((notification) => this.pendingNotifications.set(notification.id, notification))
 
     // Connect
+    logger.debug(`[CmsNotificationProducer] Connecting to push notifications queue`)
     await this.props.pushNotificationsRepository.connect()
 
     // Post notifications to queue
+    logger.info(`[CmsNotificationProducer] Sending ${pushNotifications.length} notification(s) to the queue`)
     this.props.pushNotificationsRepository.send(pushNotifications)
     this.pendingNotifications.clear()
   }

--- a/apps/notification-producer/src/producers/cms/CmsNotificationProducer.ts
+++ b/apps/notification-producer/src/producers/cms/CmsNotificationProducer.ts
@@ -1,3 +1,4 @@
+import { getAddressKey } from '@cowprotocol/cow-sdk'
 import { PushNotification } from '@cowprotocol/notifications'
 import { CmsPushNotification, PushNotificationsRepository } from '@cowprotocol/repositories'
 import Mustache from 'mustache'
@@ -53,7 +54,7 @@ export class CmsNotificationProducer implements Runnable {
   }
 
   async fetchAndSend(): Promise<void> {
-    const accounts = (await this.props.pushSubscriptionsRepository.getAllSubscribedAccounts()).map(account => account.toLowerCase())
+    const accounts = (await this.props.pushSubscriptionsRepository.getAllSubscribedAccounts()).map(getAddressKey)
     logger.debug(
       `[CmsNotificationProducer] Watching ${accounts.length} subscribed account(s): ${JSON.stringify(accounts)}`
     )
@@ -64,7 +65,7 @@ export class CmsNotificationProducer implements Runnable {
 
     const cmsPushNotifications = allCmsPushNotifications.filter(
       // Include only the notifications for subscribed accounts
-      ({ account }) => accounts.includes(account.toLowerCase())
+      ({ account }) => accounts.includes(getAddressKey(account))
     )
     logger.debug(
       `[CmsNotificationProducer] ${cmsPushNotifications.length} of ${allCmsPushNotifications.length} CMS notification(s) match a subscribed account`
@@ -114,7 +115,7 @@ function fromCmsToNotifications(cmsNotification: CmsPushNotification): PushNotif
     id: cmsNotificationId,
     title,
     message,
-    account,
+    account: getAddressKey(account),
     url: url || undefined,
     context: {
       cmsId: cmsNotificationId,

--- a/apps/notification-producer/src/producers/expired-orders/ExpiredOrdersNotificationProducer.ts
+++ b/apps/notification-producer/src/producers/expired-orders/ExpiredOrdersNotificationProducer.ts
@@ -1,4 +1,5 @@
 import {
+  areAddressesEqual,
   BARN_ETH_FLOW_ADDRESSES,
   CowEnv,
   ETH_FLOW_ADDRESSES,
@@ -136,7 +137,7 @@ export class ExpiredOrdersNotificationProducer implements Runnable {
 
       const notifications = await Promise.all(
         expiredOrders.map((order) => {
-          const isEthFlowOrder = ethFlowAddress === getAddressKey(order.owner)
+          const isEthFlowOrder = areAddressesEqual(ethFlowAddress, order.owner)
 
           const orderOwner = isEthFlowOrder
             ? Object.keys(ethFlowOrderOwners).find((key) => {

--- a/apps/notification-producer/src/producers/expired-orders/ExpiredOrdersNotificationProducer.ts
+++ b/apps/notification-producer/src/producers/expired-orders/ExpiredOrdersNotificationProducer.ts
@@ -1,4 +1,4 @@
-import { BARN_ETH_FLOW_ADDRESSES, ETH_FLOW_ADDRESSES, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { BARN_ETH_FLOW_ADDRESSES, ETH_FLOW_ADDRESSES, getAddressKey, SupportedChainId } from '@cowprotocol/cow-sdk'
 import {
   Erc20Repository,
   ExpiredOrdersRepository,
@@ -104,9 +104,7 @@ export class ExpiredOrdersNotificationProducer implements Runnable {
     if (lastCheckTimestampRaw) {
       const lastCheckTimestamp = Number(lastCheckTimestampRaw)
 
-      const ethFlowAddresses = [ETH_FLOW_ADDRESSES[chainId], BARN_ETH_FLOW_ADDRESSES[chainId]].map((t) =>
-        t.toLowerCase()
-      )
+      const ethFlowAddresses = [ETH_FLOW_ADDRESSES[chainId], BARN_ETH_FLOW_ADDRESSES[chainId]].map(getAddressKey)
 
       const accounts = await pushSubscriptionsRepository.getAllSubscribedAccounts()
 
@@ -130,15 +128,16 @@ export class ExpiredOrdersNotificationProducer implements Runnable {
 
       const notifications = await Promise.all(
         expiredOrders.map((order) => {
-          const isEthFlowOrder = ethFlowAddresses.includes(order.owner.toLowerCase())
+          const isEthFlowOrder = ethFlowAddresses.includes(getAddressKey(order.owner))
 
           const orderOwner = isEthFlowOrder
             ? Object.keys(ethFlowOrderOwners).find((key) => {
                 const orderUids = ethFlowOrderOwners[key]
 
+                // order.uid is a 56-byte order digest, not an address, so getAddressKey() would leave it untouched: plain lowercase is correct here.
                 return orderUids.includes(order.uid.toLowerCase())
               })
-            : order.owner.toLowerCase()
+            : getAddressKey(order.owner)
 
           if (!orderOwner) return Promise.resolve(undefined)
 

--- a/apps/notification-producer/src/producers/expired-orders/ExpiredOrdersNotificationProducer.ts
+++ b/apps/notification-producer/src/producers/expired-orders/ExpiredOrdersNotificationProducer.ts
@@ -1,4 +1,10 @@
-import { BARN_ETH_FLOW_ADDRESSES, ETH_FLOW_ADDRESSES, getAddressKey, SupportedChainId } from '@cowprotocol/cow-sdk'
+import {
+  BARN_ETH_FLOW_ADDRESSES,
+  CowEnv,
+  ETH_FLOW_ADDRESSES,
+  getAddressKey,
+  SupportedChainId,
+} from '@cowprotocol/cow-sdk'
 import {
   Erc20Repository,
   ExpiredOrdersRepository,
@@ -104,13 +110,15 @@ export class ExpiredOrdersNotificationProducer implements Runnable {
     if (lastCheckTimestampRaw) {
       const lastCheckTimestamp = Number(lastCheckTimestampRaw)
 
-      const ethFlowAddresses = [ETH_FLOW_ADDRESSES[chainId], BARN_ETH_FLOW_ADDRESSES[chainId]].map(getAddressKey)
-
+      const env: CowEnv = process.env.COW_PROTOCOL_ENV === 'staging' ? 'staging' : 'prod'
+      const ethFlowAddress = getAddressKey(
+        env === 'staging' ? BARN_ETH_FLOW_ADDRESSES[chainId] : ETH_FLOW_ADDRESSES[chainId]
+      )
       const accounts = await pushSubscriptionsRepository.getAllSubscribedAccounts()
 
       const expiredOrders = await expiredOrdersRepository.fetchExpiredOrdersForAccounts({
         chainId,
-        accounts: [...accounts, ...ethFlowAddresses],
+        accounts: [...accounts, ethFlowAddress],
         lastCheckTimestamp,
         nowTimestamp,
       })
@@ -128,7 +136,7 @@ export class ExpiredOrdersNotificationProducer implements Runnable {
 
       const notifications = await Promise.all(
         expiredOrders.map((order) => {
-          const isEthFlowOrder = ethFlowAddresses.includes(getAddressKey(order.owner))
+          const isEthFlowOrder = ethFlowAddress === getAddressKey(order.owner)
 
           const orderOwner = isEthFlowOrder
             ? Object.keys(ethFlowOrderOwners).find((key) => {

--- a/apps/notification-producer/src/producers/expired-orders/getExpiredOrderNotification.ts
+++ b/apps/notification-producer/src/producers/expired-orders/getExpiredOrderNotification.ts
@@ -39,7 +39,9 @@ export async function getExpiredOrderNotification(
 
   return {
     id: 'OrderExpired-' + expiredOrder.uid + '-' + expiredOrder.validTo + '-' + lastCheckTimestamp,
-    account: expiredOrder.owner.toLowerCase(),
+    // Use the resolved owner (not expiredOrder.owner): for eth-flow orders expiredOrder.owner is the
+    // eth-flow contract address, not the actual trader who should receive the notification.
+    account: owner,
     title,
     message,
     url,

--- a/apps/notification-producer/src/producers/trade/TradeNotificationProducer.ts
+++ b/apps/notification-producer/src/producers/trade/TradeNotificationProducer.ts
@@ -12,7 +12,7 @@ import { BlockNotFoundError } from 'viem'
 import { Runnable } from '../../../types'
 import { PushSubscriptionsRepository } from '@cowprotocol/repositories'
 import { IndexerStateRepository } from '@cowprotocol/repositories'
-import { doForever, logger } from '@cowprotocol/shared'
+import { doForever, EvmChainId, logger } from '@cowprotocol/shared'
 import { getTradeNotifications } from './getTradeNotifications'
 
 const WAIT_TIME = 10000
@@ -87,7 +87,7 @@ export class TradeNotificationProducer implements Runnable {
     const stateRegistry = await indexerStateRepository.get<TradeNotificationProducerState>(PRODUCER_NAME, chainId)
 
     // Get last block
-    const client = getViemClients()[chainId]
+    const client = getViemClients()[chainId as EvmChainId]
     const lastBlock = await client.getBlock()
     const toBlockFinal = lastBlock.number
 
@@ -99,7 +99,7 @@ export class TradeNotificationProducer implements Runnable {
     // Print debug message
     if (totalBlocksToIndex < 1n) {
       // We are up to date. Nothing to index
-      logger.trace(`${this.prefix} No new blocks to index`)
+      logger.debug(`${this.prefix} No new blocks to index. Last indexed block: ${toBlockFinal}`)
       return NO_PENDING_BLOCKS
     } else {
       logger.debug(`${this.prefix} Indexing from block ${fromBlock} to ${toBlockFinal}: ${totalBlocksToIndex} blocks`)
@@ -178,6 +178,11 @@ export class TradeNotificationProducer implements Runnable {
 
     // Get all accounts subscribed to PUSH notifications
     const accounts = await pushSubscriptionsRepository.getAllSubscribedAccounts()
+    logger.debug(
+      `${this.prefix} Watching ${
+        accounts.length
+      } subscribed account(s) for blocks ${fromBlock}-${toBlock}: ${JSON.stringify(accounts)}`
+    )
 
     // Get all trade notifications for the block range
     const notificationPromises = getTradeNotifications({
@@ -198,7 +203,9 @@ export class TradeNotificationProducer implements Runnable {
     const notifications = await notificationPromises
 
     // Return early if there are no notifications
-    if (notifications.length > 0) {
+    if (notifications.length === 0) {
+      logger.debug(`${this.prefix} No trade notifications to send for blocks ${fromBlock}-${toBlock}`)
+    } else {
       logger.info(
         `${this.prefix} Sending ${notifications.length} notifications`,
         JSON.stringify(notifications, null, 2)

--- a/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
+++ b/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
@@ -4,6 +4,7 @@ import {
   COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS_STAGING,
   CowEnv,
   ETH_FLOW_ADDRESSES,
+  getAddressKey,
   SupportedChainId,
   LatestAppDataDocVersion,
 } from '@cowprotocol/cow-sdk'
@@ -48,7 +49,7 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
 
   const client = getViemClients()[chainId as EvmChainId]
 
-  const ethFlowAddresses = [ETH_FLOW_ADDRESSES[chainId], BARN_ETH_FLOW_ADDRESSES[chainId]].map((t) => t.toLowerCase())
+  const ethFlowAddresses = [ETH_FLOW_ADDRESSES[chainId], BARN_ETH_FLOW_ADDRESSES[chainId]].map(getAddressKey)
   const owners = [...accounts, ...ethFlowAddresses]
 
   const env: CowEnv = process.env.COW_PROTOCOL_ENV === 'staging' ? 'staging' : 'prod'
@@ -95,7 +96,7 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
 
     if (log.eventName !== 'Trade') return acc
     if (!orderUid) return acc
-    if (!owner || !ethFlowAddresses.includes(owner.toLowerCase())) return acc
+    if (!owner || !ethFlowAddresses.includes(getAddressKey(owner))) return acc
 
     acc.push(orderUid)
 
@@ -134,8 +135,9 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
           break
         }
 
+        // orderUid is a 56-byte order digest, not an address, so getAddressKey() would leave it untouched: plain lowercase is correct here.
         const orderUidLower = orderUid.toLowerCase()
-        const isEthFlowOrder = ethFlowAddresses.includes(owner.toLowerCase())
+        const isEthFlowOrder = ethFlowAddresses.includes(getAddressKey(owner))
         const appData = ordersAppData.get(orderUidLower)
         const isBridgingOrder = !!(appData as LatestAppDataDocVersion)?.metadata?.bridging
 
@@ -145,7 +147,7 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
 
               return orderUids.includes(orderUidLower)
             })
-          : owner.toLowerCase()
+          : getAddressKey(owner)
 
         if (!orderOwner) {
           logger.debug(

--- a/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
+++ b/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
@@ -1,6 +1,8 @@
 import {
   BARN_ETH_FLOW_ADDRESSES,
   COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS,
+  COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS_STAGING,
+  CowEnv,
   ETH_FLOW_ADDRESSES,
   SupportedChainId,
   LatestAppDataDocVersion,
@@ -12,7 +14,7 @@ import {
   OnChainPlacedOrdersRepository,
   OrdersAppDataRepository,
 } from '@cowprotocol/repositories'
-import { bigIntReplacer, logger } from '@cowprotocol/shared'
+import { bigIntReplacer, EvmChainId, logger } from '@cowprotocol/shared'
 import { getAddress, parseAbi } from 'viem'
 import { fromTradeToNotification } from './fromTradeToNotification'
 
@@ -44,22 +46,35 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
     prefix,
   } = params
 
-  const client = getViemClients()[chainId]
+  const client = getViemClients()[chainId as EvmChainId]
 
   const ethFlowAddresses = [ETH_FLOW_ADDRESSES[chainId], BARN_ETH_FLOW_ADDRESSES[chainId]].map((t) => t.toLowerCase())
+  const owners = [...accounts, ...ethFlowAddresses]
+
+  const env: CowEnv = process.env.COW_PROTOCOL_ENV === 'staging' ? 'staging' : 'prod'
+  const settlementAddresses =
+    env === 'staging' ? COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS_STAGING : COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS
+  const settlementAddress = settlementAddresses[chainId]
+
+  logger.debug(
+    `${prefix} Fetching Trade logs from block ${fromBlock} to ${toBlock} on settlement contract ${settlementAddress}, filtered to ${owners.length} owner(s) (${accounts.length} subscribed + ${ethFlowAddresses.length} eth-flow)`
+  )
 
   const logs = await client.getLogs({
     events: EVENTS,
     fromBlock,
     toBlock,
-    address: getAddress(COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS[chainId]),
+    address: getAddress(settlementAddress),
     args: {
-      owner: [...accounts, ...ethFlowAddresses],
+      owner: owners,
     } as any,
   })
 
   // Return empty array if no events
   if (logs.length === 0) {
+    logger.debug(
+      `${prefix} No Trade events found for blocks ${fromBlock}-${toBlock} matching the ${owners.length} watched owner(s). Note: trades from accounts not subscribed to push notifications (and not eth-flow) are filtered out at the RPC log query level and will never appear here.`
+    )
     return []
   }
 
@@ -131,6 +146,14 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
               return orderUids.includes(orderUidLower)
             })
           : owner.toLowerCase()
+
+        if (!orderOwner) {
+          logger.debug(
+            `${prefix} Skipping eth-flow order ${orderUidLower} (tx=${log.transactionHash}): no matching owner found in on-chain placed orders`
+          )
+        } else if (isBridgingOrder) {
+          logger.debug(`${prefix} Skipping bridging order ${orderUidLower} (tx=${log.transactionHash})`)
+        }
 
         if (orderOwner && !isBridgingOrder) {
           acc.push(

--- a/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
+++ b/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
@@ -49,16 +49,19 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
 
   const client = getViemClients()[chainId as EvmChainId]
 
-  const ethFlowAddresses = [ETH_FLOW_ADDRESSES[chainId], BARN_ETH_FLOW_ADDRESSES[chainId]].map(getAddressKey)
-  const owners = [...accounts, ...ethFlowAddresses]
-
   const env: CowEnv = process.env.COW_PROTOCOL_ENV === 'staging' ? 'staging' : 'prod'
+
+  const ethFlowAddress = getAddressKey(
+    env === 'staging' ? BARN_ETH_FLOW_ADDRESSES[chainId] : ETH_FLOW_ADDRESSES[chainId]
+  )
+  const owners = [...accounts, ethFlowAddress]
+
   const settlementAddresses =
     env === 'staging' ? COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS_STAGING : COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS
   const settlementAddress = settlementAddresses[chainId]
 
   logger.debug(
-    `${prefix} Fetching Trade logs from block ${fromBlock} to ${toBlock} on settlement contract ${settlementAddress}, filtered to ${owners.length} owner(s) (${accounts.length} subscribed + ${ethFlowAddresses.length} eth-flow)`
+    `${prefix} Fetching Trade logs from block ${fromBlock} to ${toBlock} on settlement contract ${settlementAddress}, filtered to ${owners.length} owner(s) (${accounts.length} subscribed + ${ethFlowAddress} eth-flow)`
   )
 
   const logs = await client.getLogs({
@@ -96,7 +99,7 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
 
     if (log.eventName !== 'Trade') return acc
     if (!orderUid) return acc
-    if (!owner || !ethFlowAddresses.includes(getAddressKey(owner))) return acc
+    if (!owner || ethFlowAddress !== getAddressKey(owner)) return acc
 
     acc.push(orderUid)
 
@@ -137,7 +140,7 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
 
         // orderUid is a 56-byte order digest, not an address, so getAddressKey() would leave it untouched: plain lowercase is correct here.
         const orderUidLower = orderUid.toLowerCase()
-        const isEthFlowOrder = ethFlowAddresses.includes(getAddressKey(owner))
+        const isEthFlowOrder = ethFlowAddress === getAddressKey(owner)
         const appData = ordersAppData.get(orderUidLower)
         const isBridgingOrder = !!(appData as LatestAppDataDocVersion)?.metadata?.bridging
 

--- a/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
+++ b/apps/notification-producer/src/producers/trade/getTradeNotifications.ts
@@ -7,6 +7,7 @@ import {
   getAddressKey,
   SupportedChainId,
   LatestAppDataDocVersion,
+  areAddressesEqual,
 } from '@cowprotocol/cow-sdk'
 import { PushNotification } from '@cowprotocol/notifications'
 import {
@@ -99,7 +100,7 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
 
     if (log.eventName !== 'Trade') return acc
     if (!orderUid) return acc
-    if (!owner || ethFlowAddress !== getAddressKey(owner)) return acc
+    if (!owner || !areAddressesEqual(ethFlowAddress, owner)) return acc
 
     acc.push(orderUid)
 
@@ -140,7 +141,7 @@ export async function getTradeNotifications(params: GetTradeNotificationParams) 
 
         // orderUid is a 56-byte order digest, not an address, so getAddressKey() would leave it untouched: plain lowercase is correct here.
         const orderUidLower = orderUid.toLowerCase()
-        const isEthFlowOrder = ethFlowAddress === getAddressKey(owner)
+        const isEthFlowOrder = areAddressesEqual(ethFlowAddress, owner)
         const appData = ordersAppData.get(orderUidLower)
         const isBridgingOrder = !!(appData as LatestAppDataDocVersion)?.metadata?.bridging
 

--- a/apps/notification-producer/src/utils/getNotificationSummary.ts
+++ b/apps/notification-producer/src/utils/getNotificationSummary.ts
@@ -1,5 +1,4 @@
-import { EVM_NATIVE_CURRENCY_ADDRESS, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { getAddress } from 'viem'
+import { EVM_NATIVE_CURRENCY_ADDRESS, getAddressKey, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ChainNames, formatAmount, formatTokenName } from '@cowprotocol/shared'
 import { Erc20Repository } from '@cowprotocol/repositories'
 
@@ -18,10 +17,10 @@ export async function getNotificationSummary(params: OrderInfoForNotificationPar
 
   const sellToken = await erc20Repository.get(
     chainId,
-    isEthFlowOrder ? EVM_NATIVE_CURRENCY_ADDRESS : getAddress(params.sellTokenAddress)
+    isEthFlowOrder ? getAddressKey(EVM_NATIVE_CURRENCY_ADDRESS) : getAddressKey(params.sellTokenAddress)
   )
 
-  const buyToken = await erc20Repository.get(chainId, getAddress(params.buyTokenAddress))
+  const buyToken = await erc20Repository.get(chainId, getAddressKey(params.buyTokenAddress))
 
   const sellAmountFormatted = formatAmount(BigInt(params.sellAmount), sellToken?.decimals)
   const buyAmountFormatted = formatAmount(BigInt(params.buyAmount), buyToken?.decimals)

--- a/apps/twap/src/app/utils/getApiBaseUrl.ts
+++ b/apps/twap/src/app/utils/getApiBaseUrl.ts
@@ -1,9 +1,8 @@
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { COW_API_NETWORK_NAMES } from '@cowprotocol/shared'
+import { COW_API_NETWORK_NAMES, EvmChainId } from '@cowprotocol/shared'
 
 const COW_API_BASE_URL = 'https://api.cow.fi'
 
-export function getApiBaseUrl(chainId: SupportedChainId): string {
+export function getApiBaseUrl(chainId: EvmChainId): string {
   const chainName = COW_API_NETWORK_NAMES[chainId]
 
   return `${COW_API_BASE_URL}/${chainName}/v1`

--- a/libs/repositories/src/const.ts
+++ b/libs/repositories/src/const.ts
@@ -1,4 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { EvmChainId } from '@cowprotocol/shared'
 import BigNumber from 'bignumber.js'
 
 interface TokenAddressAndDecimals {
@@ -54,7 +55,7 @@ export const USDC = {
     address: '0xbe72E441BF55620febc26715db68d3494213D8Cb',
     decimals: 18,
   },
-} as const satisfies Record<SupportedChainId, TokenAddressAndDecimals>
+} as const satisfies Record<EvmChainId, TokenAddressAndDecimals>
 
 export const ZeroBigNumber = new BigNumber(0)
 export const OneBigNumber = new BigNumber(1)

--- a/libs/repositories/src/datasources/coingecko.ts
+++ b/libs/repositories/src/datasources/coingecko.ts
@@ -1,5 +1,8 @@
 import { AdditionalTargetChainId, SupportedChainId, TargetChainId } from '@cowprotocol/cow-sdk'
 
+// Solana is not supported by this repo (no Solana RPC client, contracts, etc.)
+type EvmTargetChainId = Exclude<TargetChainId, SupportedChainId.SOLANA>
+
 import createClient from 'openapi-fetch'
 import type { components, paths } from '../gen/coingecko/coingecko-pro-types'
 
@@ -19,8 +22,7 @@ export const SUPPORTED_COINGECKO_PLATFORMS = {
   [SupportedChainId.INK]: 'ink',
   [AdditionalTargetChainId.OPTIMISM]: 'optimistic-ethereum',
   [AdditionalTargetChainId.BITCOIN]: 'bitcoin',
-  [AdditionalTargetChainId.SOLANA]: 'solana',
-} as const satisfies Record<TargetChainId, string | undefined>
+} as const satisfies Record<EvmTargetChainId, string | undefined>
 
 /**
  * Map of chain IDs to Coingecko platform IDs, for every platform that has a network id.

--- a/libs/repositories/src/datasources/coingecko.ts
+++ b/libs/repositories/src/datasources/coingecko.ts
@@ -1,8 +1,5 @@
 import { AdditionalTargetChainId, SupportedChainId, TargetChainId } from '@cowprotocol/cow-sdk'
 
-// Solana is not supported by this repo (no Solana RPC client, contracts, etc.)
-type EvmTargetChainId = Exclude<TargetChainId, SupportedChainId.SOLANA>
-
 import createClient from 'openapi-fetch'
 import type { components, paths } from '../gen/coingecko/coingecko-pro-types'
 
@@ -22,7 +19,10 @@ export const SUPPORTED_COINGECKO_PLATFORMS = {
   [SupportedChainId.INK]: 'ink',
   [AdditionalTargetChainId.OPTIMISM]: 'optimistic-ethereum',
   [AdditionalTargetChainId.BITCOIN]: 'bitcoin',
-} as const satisfies Record<EvmTargetChainId, string | undefined>
+  // Solana moved from AdditionalTargetChainId to SupportedChainId in the SDK; this repo has no on-chain
+  // Solana support (RPC client, contracts, etc.), but USD prices via CoinGecko still work for it.
+  [SupportedChainId.SOLANA]: 'solana',
+} as const satisfies Record<TargetChainId, string | undefined>
 
 /**
  * Map of chain IDs to Coingecko platform IDs, for every platform that has a network id.

--- a/libs/repositories/src/datasources/cowApi.ts
+++ b/libs/repositories/src/datasources/cowApi.ts
@@ -2,12 +2,13 @@ import createClient from 'openapi-fetch'
 
 const COW_API_BASE_URL = process.env.COW_API_BASE_URL || 'https://api.cow.fi'
 
-import { AllChainIds, COW_API_NETWORK_NAMES, EvmChainId } from '@cowprotocol/shared'
+import { COW_API_NETWORK_NAMES, EVM_CHAIN_IDS, EvmChainId } from '@cowprotocol/shared'
 import type { paths } from '../gen/cow/cow-api-types'
 
 export type CowApiClient = ReturnType<typeof createClient<paths>>
 
-export const cowApiClients = AllChainIds.reduce<Record<EvmChainId, CowApiClient>>((acc, chainId) => {
+// CoW API only exists for EVM chains with CoW Protocol settlement, so Solana is excluded here.
+export const cowApiClients = EVM_CHAIN_IDS.reduce<Record<EvmChainId, CowApiClient>>((acc, chainId) => {
   const cowApiUrl = process.env[`COW_API_URL_${chainId}`] || COW_API_BASE_URL + '/' + COW_API_NETWORK_NAMES[chainId]
 
   acc[chainId] = createClient<paths>({

--- a/libs/repositories/src/datasources/cowApi.ts
+++ b/libs/repositories/src/datasources/cowApi.ts
@@ -2,13 +2,12 @@ import createClient from 'openapi-fetch'
 
 const COW_API_BASE_URL = process.env.COW_API_BASE_URL || 'https://api.cow.fi'
 
-import { AllChainIds, COW_API_NETWORK_NAMES } from '@cowprotocol/shared'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { AllChainIds, COW_API_NETWORK_NAMES, EvmChainId } from '@cowprotocol/shared'
 import type { paths } from '../gen/cow/cow-api-types'
 
 export type CowApiClient = ReturnType<typeof createClient<paths>>
 
-export const cowApiClients = AllChainIds.reduce<Record<SupportedChainId, CowApiClient>>((acc, chainId) => {
+export const cowApiClients = AllChainIds.reduce<Record<EvmChainId, CowApiClient>>((acc, chainId) => {
   const cowApiUrl = process.env[`COW_API_URL_${chainId}`] || COW_API_BASE_URL + '/' + COW_API_NETWORK_NAMES[chainId]
 
   acc[chainId] = createClient<paths>({
@@ -16,4 +15,4 @@ export const cowApiClients = AllChainIds.reduce<Record<SupportedChainId, CowApiC
   })
 
   return acc
-}, {} as Record<SupportedChainId, CowApiClient>)
+}, {} as Record<EvmChainId, CowApiClient>)

--- a/libs/repositories/src/datasources/ethplorer.ts
+++ b/libs/repositories/src/datasources/ethplorer.ts
@@ -1,4 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { EvmChainId } from '@cowprotocol/shared'
 
 export const ETHPLORER_API_KEY = process.env.ETHPLORER_API_KEY as string
 
@@ -17,4 +18,4 @@ export const ETHPLORER_BASE_URL = {
   [SupportedChainId.LINEA]: 'https://api.lineaplorer.build',
   [SupportedChainId.PLASMA]: null,
   [SupportedChainId.INK]: null,
-} as const satisfies Record<SupportedChainId, string | null>
+} as const satisfies Record<EvmChainId, string | null>

--- a/libs/repositories/src/datasources/goldRush.ts
+++ b/libs/repositories/src/datasources/goldRush.ts
@@ -1,4 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { EvmChainId } from '@cowprotocol/shared'
 
 export const GOLD_RUSH_API_KEY = process.env.GOLD_RUSH_API_KEY
 export const GOLD_RUSH_API_BASE_URL = 'https://api.covalenthq.com'
@@ -18,4 +19,4 @@ export const GOLD_RUSH_CLIENT_NETWORK_MAPPING = {
   [SupportedChainId.LINEA]: 'linea-mainnet',
   [SupportedChainId.PLASMA]: 'plasma-mainnet',
   [SupportedChainId.INK]: 'ink-mainnet',
-} as const satisfies Record<SupportedChainId, string>
+} as const satisfies Record<EvmChainId, string>

--- a/libs/repositories/src/datasources/moralis.ts
+++ b/libs/repositories/src/datasources/moralis.ts
@@ -1,4 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { EvmChainId } from '@cowprotocol/shared'
 
 export const MORALIS_API_KEY = process.env.MORALIS_API_KEY
 export const MORALIS_API_BASE_URL = 'https://deep-index.moralis.io/api'
@@ -18,4 +19,4 @@ export const MORALIS_CLIENT_NETWORK_MAPPING = {
   [SupportedChainId.LINEA]: 'linea',
   [SupportedChainId.PLASMA]: null,
   [SupportedChainId.INK]: null,
-} as const satisfies Record<SupportedChainId, string | null>
+} as const satisfies Record<EvmChainId, string | null>

--- a/libs/repositories/src/datasources/orderBookDbPool.ts
+++ b/libs/repositories/src/datasources/orderBookDbPool.ts
@@ -1,5 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { ensureEnvs } from '@cowprotocol/shared'
+import { ensureEnvs, EvmChainId } from '@cowprotocol/shared'
 import { Pool } from 'pg'
 
 const REQUIRED_ENVS = [
@@ -21,7 +21,7 @@ const chainToDbNameMap = {
   [SupportedChainId.LINEA]: 'linea',
   [SupportedChainId.PLASMA]: 'plasma',
   [SupportedChainId.INK]: 'ink',
-} as const satisfies Record<SupportedChainId, string>
+} as const satisfies Record<EvmChainId, string>
 
 function createNewOrderBookDbPool(env: 'prod' | 'barn', chainId: SupportedChainId): Pool {
   const ENV_PREFIX = env.toUpperCase()
@@ -31,7 +31,7 @@ function createNewOrderBookDbPool(env: 'prod' | 'barn', chainId: SupportedChainI
   const pool = new Pool({
     user: process.env[`${ENV_PREFIX}_ORDERBOOK_DATABASE_USERNAME`],
     host: process.env[`${ENV_PREFIX}_ORDERBOOK_DATABASE_HOST`],
-    database: chainToDbNameMap[chainId],
+    database: chainToDbNameMap[chainId as EvmChainId],
     password: process.env[`${ENV_PREFIX}_ORDERBOOK_DATABASE_PASSWORD`],
     port: Number(process.env[`${ENV_PREFIX}_ORDERBOOK_DATABASE_PORT`]),
     keepAlive: true,

--- a/libs/repositories/src/datasources/viem.ts
+++ b/libs/repositories/src/datasources/viem.ts
@@ -1,5 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { AllChainIds, logger } from '@cowprotocol/shared'
+import { AllChainIds, EvmChainId, logger } from '@cowprotocol/shared'
 import { Chain, createPublicClient, http, PublicClient, webSocket } from 'viem'
 import { arbitrum, avalanche, base, bsc, gnosis, linea, mainnet, plasma, polygon, sepolia, ink } from 'viem/chains'
 
@@ -15,16 +15,16 @@ const NETWORKS = {
   [SupportedChainId.LINEA]: linea,
   [SupportedChainId.PLASMA]: plasma,
   [SupportedChainId.INK]: ink,
-} as const satisfies Record<SupportedChainId, Chain>
+} as const satisfies Record<EvmChainId, Chain>
 
-let viemClients: Record<SupportedChainId, PublicClient> | undefined
+let viemClients: Record<EvmChainId, PublicClient> | undefined
 
-export function getViemClients(): Record<SupportedChainId, PublicClient> {
+export function getViemClients(): Record<EvmChainId, PublicClient> {
   if (viemClients) {
     return viemClients
   }
 
-  viemClients = AllChainIds.reduce<Record<SupportedChainId, PublicClient>>((acc, chainId) => {
+  viemClients = AllChainIds.reduce<Record<EvmChainId, PublicClient>>((acc, chainId) => {
     const chain = NETWORKS[chainId]
     const envVarName = `RPC_URL_${chainId}`
     const rpcEndpoint = process.env[envVarName]
@@ -50,7 +50,7 @@ export function getViemClients(): Record<SupportedChainId, PublicClient> {
     }) as PublicClient
 
     return acc
-  }, {} as Record<SupportedChainId, PublicClient>)
+  }, {} as Record<EvmChainId, PublicClient>)
 
   return viemClients
 }

--- a/libs/repositories/src/datasources/viem.ts
+++ b/libs/repositories/src/datasources/viem.ts
@@ -1,5 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { AllChainIds, EvmChainId, logger } from '@cowprotocol/shared'
+import { EVM_CHAIN_IDS, EvmChainId, logger } from '@cowprotocol/shared'
 import { Chain, createPublicClient, http, PublicClient, webSocket } from 'viem'
 import { arbitrum, avalanche, base, bsc, gnosis, linea, mainnet, plasma, polygon, sepolia, ink } from 'viem/chains'
 
@@ -24,7 +24,7 @@ export function getViemClients(): Record<EvmChainId, PublicClient> {
     return viemClients
   }
 
-  viemClients = AllChainIds.reduce<Record<EvmChainId, PublicClient>>((acc, chainId) => {
+  viemClients = EVM_CHAIN_IDS.reduce<Record<EvmChainId, PublicClient>>((acc, chainId) => {
     const chain = NETWORKS[chainId]
     const envVarName = `RPC_URL_${chainId}`
     const rpcEndpoint = process.env[envVarName]

--- a/libs/repositories/src/gen/cow/cow-api-types.ts
+++ b/libs/repositories/src/gen/cow/cow-api-types.ts
@@ -265,66 +265,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/solver_competition/{auction_id}": {
+    "/api/v1/quote/stream": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
+        get?: never;
+        put?: never;
         /**
-         * Get information about a solver competition.
-         * @deprecated
-         * @description Returns the competition information by `auction_id`.
+         * Stream progressively improving quotes as solvers respond.
+         * @description Accepts the same request body as `POST /api/v1/quote`. Instead of waiting for all solvers and returning the single best quote, this endpoint opens a Server-Sent Events stream and emits quotes as solvers respond. A quote is emitted only when it ranks better than the best one already sent; the first goes out as soon as the fastest solver answers. Solvers without a usable quote, and quotes that do not beat the best already sent, emit no event, so you may receive fewer events than there are solvers. The stream closes when the quote timeout elapses or all solvers have responded. Each emitted quote carries an `id` that can be referenced when placing an order.
+         *     The `priceQuality` field of the request body is ignored: this endpoint always queries all solvers and attempts verification, and each emitted quote carries its own `verified` flag. A verified quote ranks above an unverified one regardless of amount, so a later quote may report a lower `out_amount`. Individual solver errors are not streamed; if no solver returns a usable quote, a terminal event named `error` is sent with a `PriceEstimationError` body before the stream closes.
          *
          */
-        get: operations["getSolverCompetitionByAuctionId"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/solver_competition/by_tx_hash/{tx_hash}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get information about solver competition.
-         * @deprecated
-         * @description Returns the competition information by `tx_hash`.
-         *
-         */
-        get: operations["getSolverCompetitionByTxHash"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/solver_competition/latest": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get information about the most recent solver competition.
-         * @deprecated
-         * @description Returns the competition information for the last seen auction_id.
-         *
-         */
-        get: operations["getSolverCompetitionLatest"];
-        put?: never;
-        post?: never;
+        post: operations["quoteStream"];
         delete?: never;
         options?: never;
         head?: never;
@@ -481,7 +437,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/debug/simulation": {
+    "/restricted/api/v1/debug/simulation": {
         parameters: {
             query?: never;
             header?: never;
@@ -502,7 +458,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/debug/simulation/{uid}": {
+    "/restricted/api/v1/debug/simulation/{uid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -523,7 +479,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/debug/order/{uid}": {
+    "/restricted/api/v1/debug/order/{uid}": {
         parameters: {
             query?: never;
             header?: never;
@@ -628,11 +584,21 @@ export interface components {
         OrderClass: "market" | "limit" | "liquidity";
         /**
          * @description Where should the `sellToken` be drawn from?
+         *
+         *     **Only `erc20` is accepted for new orders.** The `internal` and `external`
+         *     (Balancer Vault) sources are deprecated: orders using them are rejected at
+         *     creation with `UnsupportedSellTokenSource`. The values remain in the enum
+         *     because they may still appear on historical orders returned by the API.
          * @enum {string}
          */
         SellTokenSource: "erc20" | "internal" | "external";
         /**
          * @description Where should the `buyToken` be transferred to?
+         *
+         *     **Only `erc20` is accepted for new orders.** The `internal` (Balancer Vault)
+         *     destination is rejected at creation with `UnsupportedBuyTokenDestination`.
+         *     The value remains in the enum because it may still appear on historical
+         *     orders returned by the API.
          * @enum {string}
          */
         BuyTokenDestination: "erc20" | "internal";
@@ -707,12 +673,14 @@ export interface components {
             /** @description Is the order fill-or-kill or partially fillable? */
             partiallyFillable: boolean;
             /**
+             * @deprecated
              * @description Where the sell token should be drawn from. Defaults to `erc20` for standard ERC-20 token transfers.
              *
              * @default erc20
              */
             sellTokenBalance: components["schemas"]["SellTokenSource"];
             /**
+             * @deprecated
              * @description Where the buy token should be transferred to. Defaults to `erc20` for standard ERC-20 token transfers.
              *
              * @default erc20
@@ -746,11 +714,13 @@ export interface components {
             /** @description see `OrderParameters::partiallyFillable` */
             partiallyFillable: boolean;
             /**
+             * @deprecated
              * @description see `OrderParameters::sellTokenBalance`
              * @default erc20
              */
             sellTokenBalance: components["schemas"]["SellTokenSource"];
             /**
+             * @deprecated
              * @description see `OrderParameters::buyTokenBalance`
              * @default erc20
              */
@@ -844,6 +814,9 @@ export interface components {
             /** @description Full `appData`, which the contract-level `appData` is a hash of. See `OrderCreation` for more information.
              *      */
             fullAppData?: string | null;
+            /** @description Earliest time (unix seconds) at which the order may enter a batch auction, taken from the order's `appData`. Omitted when the order has no lower bound (eligible immediately).
+             *      */
+            validFrom?: number | null;
             /** @description The address of the CoW Protocol settlement contract that this order is valid for. Orders are only valid on the settlement contract they were signed for.
              *      */
             settlementContract: components["schemas"]["Address"];
@@ -901,11 +874,13 @@ export interface components {
              *      */
             postInteractions: components["schemas"]["InteractionData"][];
             /**
+             * @deprecated
              * @description see `OrderParameters::sellTokenBalance`
              * @default erc20
              */
             sellTokenBalance: components["schemas"]["SellTokenSource"];
             /**
+             * @deprecated
              * @description see `OrderParameters::buyTokenBalance`
              * @default erc20
              */
@@ -958,7 +933,7 @@ export interface components {
              *     The presence of executed amounts defines whether the solver provided
              *     a solution for the desired order. */
             value?: {
-                /** @description Name of the solver. */
+                /** @description The on-chain address of the solver. */
                 solver: string;
                 executedAmounts?: components["schemas"]["ExecutedAmounts"];
             }[];
@@ -1053,10 +1028,26 @@ export interface components {
             errorType: "InvalidSignature" | "WrongOwner" | "OrderNotFound" | "AlreadyCancelled" | "OrderFullyExecuted" | "OrderExpired" | "OnChainOrder";
             description: string;
         };
+        /** @description Error quoting an order.
+         *
+         *     Possible `errorType` values per HTTP status:
+         *     * 400: `AppDataHashMismatch`, `CustomSolverError`, `ExcessiveValidTo`,
+         *       `InsufficientLiquidity`, `InsufficientValidTo`, `InvalidAppData`,
+         *       `InvalidNativeSellToken`, `QuoteNotVerified`, `SameBuyAndSellToken`,
+         *       `SellAmountDoesNotCoverFee`, `TokenTemporarilySuspended`,
+         *       `TradingOutsideAllowedWindow`, `UnsupportedBuyTokenDestination`,
+         *       `UnsupportedOrderType`, `UnsupportedSellTokenSource`,
+         *       `UnsupportedToken`
+         *     * 403: `Forbidden`
+         *     * 404: `NoLiquidity`
+         *     * 500: `InternalServerError`
+         *      */
         PriceEstimationError: {
             /** @enum {string} */
-            errorType: "QuoteNotVerified" | "UnsupportedToken" | "NoLiquidity" | "UnsupportedOrderType";
+            errorType: "AppDataHashMismatch" | "CustomSolverError" | "ExcessiveValidTo" | "Forbidden" | "InsufficientLiquidity" | "InsufficientValidTo" | "InternalServerError" | "InvalidAppData" | "InvalidNativeSellToken" | "NoLiquidity" | "QuoteNotVerified" | "SameBuyAndSellToken" | "SellAmountDoesNotCoverFee" | "TokenTemporarilySuspended" | "TradingOutsideAllowedWindow" | "UnsupportedBuyTokenDestination" | "UnsupportedOrderType" | "UnsupportedSellTokenSource" | "UnsupportedToken";
             description: string;
+            /** @description Optional error-specific payload: `SellAmountDoesNotCoverFee` returns an object with `fee_amount`. */
+            data?: Record<string, never>;
         };
         /** @description The buy or sell side when quoting an order. */
         OrderQuoteSide: {
@@ -1111,13 +1102,25 @@ export interface components {
              *
              *     In case they differ, the call will fail. */
             appDataHash?: components["schemas"]["AppDataHash"];
-            /** @default erc20 */
+            /**
+             * @deprecated
+             * @default erc20
+             */
             sellTokenBalance: components["schemas"]["SellTokenSource"];
-            /** @default erc20 */
+            /**
+             * @deprecated
+             * @default erc20
+             */
             buyTokenBalance: components["schemas"]["BuyTokenDestination"];
             from: components["schemas"]["Address"];
             /** @default verified */
             priceQuality: components["schemas"]["PriceQuality"];
+            /**
+             * @description Signals that this quote is intended for fast-path (out-of-competition) execution. Propagated to the solver.
+             *
+             * @default false
+             */
+            fastPath: boolean;
             /** @default eip712 */
             signingScheme: components["schemas"]["SigningScheme"];
             /**
@@ -1126,7 +1129,7 @@ export interface components {
              * @default false
              */
             onchainOrder: unknown;
-            /** @description User provided timeout in milliseconds. Can only be used to reduce the response time for quote requests if the default is too slow as values greater than the default will be capped to the default. Note that reducing the timeout can result in worse quotes because the reduced timeout might be too slow for some price estimators.
+            /** @description User provided timeout in milliseconds. If no value is provided the systems default quote timeout will be used. Values get capped at a generous maximum timeout. Note that reducing the timeout can result in worse quotes because it might be too short for some price estimators.
              *      */
             timeout?: number;
         };
@@ -1200,8 +1203,13 @@ export interface components {
             /** @description Transaction in which the solution was executed onchain (if available).
              *      */
             txHash?: components["schemas"]["TransactionHash"] | null;
-            /** @description The prices of tokens for settled user orders as passed to the settlement contract.
-             *      */
+            /**
+             * @deprecated
+             * @description Deprecated. The autopilot no longer persists per-solution uniform clearing prices, so this field will be empty for solutions of auctions produced by recent autopilots. Solutions stored before this change keep their original values.
+             *
+             *     The prices of tokens for settled user orders as passed to the settlement contract.
+             *
+             */
             clearingPrices?: {
                 [key: string]: components["schemas"]["BigUint"] | undefined;
             };
@@ -1331,8 +1339,15 @@ export interface components {
             /** @description The best quote received. */
             quote: components["schemas"]["Quote"];
         };
-        /** @description Defines the ways to calculate the protocol fee. */
-        FeePolicy: components["schemas"]["Surplus"] | components["schemas"]["Volume"] | components["schemas"]["PriceImprovement"];
+        /** @description Defines the ways to calculate the protocol fee.
+         *      */
+        FeePolicy: {
+            surplus: components["schemas"]["Surplus"];
+        } | {
+            volume: components["schemas"]["Volume"];
+        } | {
+            priceImprovement: components["schemas"]["PriceImprovement"];
+        };
         ExecutedProtocolFee: {
             policy?: components["schemas"]["FeePolicy"];
             amount?: unknown & components["schemas"]["TokenAmount"];
@@ -1511,21 +1526,30 @@ export interface components {
             owner: components["schemas"]["Address"];
             /** @description The address that will receive the buy tokens. Defaults to the owner if omitted.
              *      */
-            receiver?: components["schemas"]["Address"] | null;
+            receiver?: components["schemas"]["Address"];
             /**
+             * @deprecated
              * @description Where the sell token should be drawn from.
-             * @default erc20
              */
-            sellTokenBalance: components["schemas"]["SellTokenSource"];
+            sellTokenBalance?: components["schemas"]["SellTokenSource"];
             /**
+             * @deprecated
              * @description Where the buy token should be transferred to.
-             * @default erc20
              */
-            buyTokenBalance: components["schemas"]["BuyTokenDestination"];
-            /** @description Full app data JSON string. Defaults to `"{}"` if omitted.
+            buyTokenBalance?: components["schemas"]["BuyTokenDestination"];
+            /** @description Full app data JSON string.
              *      */
-            appData?: string | null;
-            blockNumber?: number;
+            appData: string;
+            blockNumber?: number | null;
+            signingScheme: components["schemas"]["SigningScheme"];
+            signature: components["schemas"]["Signature"];
+            /** @description The fee amount in sell token atoms. Expected to be 0; only present because it must be part of the signed order data.
+             *      */
+            feeAmount: components["schemas"]["TokenAmount"];
+            /** @description Unix timestamp (`uint32`) until which the order is valid. */
+            validTo: number;
+            /** @description Whether the order can be partially filled or must be filled all at once. */
+            partiallyFillable: boolean;
         };
         /** @description The Tenderly simulation request for an order, along with any simulation error.
          *      */
@@ -2065,6 +2089,82 @@ export interface operations {
                     "application/json": components["schemas"]["PriceEstimationError"];
                 };
             };
+            /** @description Forbidden, the order owner is deny-listed (`errorType`: `Forbidden`). */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PriceEstimationError"];
+                };
+            };
+            /** @description No route was found for the specified order (`errorType`: `NoLiquidity`). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PriceEstimationError"];
+                };
+            };
+            /** @description Unable to parse request body as valid JSON. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Too many order quotes. */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unexpected error (`errorType`: `InternalServerError`). */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PriceEstimationError"];
+                };
+            };
+        };
+    };
+    quoteStream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description The order parameters to compute quotes for. */
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OrderQuoteRequest"];
+            };
+        };
+        responses: {
+            /** @description A Server-Sent Events stream. Each event's `data` field is a JSON object matching `OrderQuoteResponse`. Events arrive as the best-ranked quote improves.
+             *      */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": components["schemas"]["OrderQuoteResponse"];
+                };
+            };
+            /** @description Error quoting order. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PriceEstimationError"];
+                };
+            };
             /** @description No route was found for the specified order. */
             404: {
                 headers: {
@@ -2088,106 +2188,6 @@ export interface operations {
             };
             /** @description Unexpected error quoting an order. */
             500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getSolverCompetitionByAuctionId: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                auction_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Competition */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SolverCompetitionResponse"];
-                };
-            };
-            /** @description Invalid auction ID. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description No competition information available for this auction id. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getSolverCompetitionByTxHash: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Transaction hash in which the competition was settled. */
-                tx_hash: components["schemas"]["TransactionHash"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Competition */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SolverCompetitionResponse"];
-                };
-            };
-            /** @description Invalid transaction hash. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description No competition information available for this `tx_hash`. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getSolverCompetitionLatest: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Competition */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SolverCompetitionResponse"];
-                };
-            };
-            /** @description No competition information available. */
-            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/libs/repositories/src/repos/Erc20Repository/Erc20RepositoryViem.ts
+++ b/libs/repositories/src/repos/Erc20Repository/Erc20RepositoryViem.ts
@@ -1,14 +1,15 @@
 import { injectable } from 'inversify'
 import { Erc20, Erc20Repository } from './Erc20Repository'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { EvmChainId } from '@cowprotocol/shared'
 import { erc20Abi, getAddress, PublicClient } from 'viem'
 
 @injectable()
 export class Erc20RepositoryViem implements Erc20Repository {
-  constructor(private viemClients: Record<SupportedChainId, PublicClient>) {}
+  constructor(private viemClients: Record<EvmChainId, PublicClient>) {}
 
   async get(chainId: SupportedChainId, tokenAddress: string): Promise<Erc20 | null> {
-    const viemClient = this.viemClients[chainId]
+    const viemClient = this.viemClients[chainId as EvmChainId]
     const tokenAddressHex = getAddress(tokenAddress)
 
     const ercTokenParams = {

--- a/libs/repositories/src/repos/TokenHolderRepository/TokenHolderRepositoryEthplorer.ts
+++ b/libs/repositories/src/repos/TokenHolderRepository/TokenHolderRepositoryEthplorer.ts
@@ -1,6 +1,7 @@
 import { injectable } from 'inversify'
 import { TokenHolderPoint, TokenHolderRepository } from './TokenHolderRepository'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { EvmChainId } from '@cowprotocol/shared'
 import { ETHPLORER_API_KEY, ETHPLORER_BASE_URL } from '../../datasources/ethplorer'
 
 interface EthplorerSuccess {
@@ -22,7 +23,7 @@ interface EthplorerError {
 @injectable()
 export class TokenHolderRepositoryEthplorer implements TokenHolderRepository {
   async getTopTokenHolders(chainId: SupportedChainId, tokenAddress: string): Promise<TokenHolderPoint[] | null> {
-    const baseAPI = ETHPLORER_BASE_URL[chainId]
+    const baseAPI = ETHPLORER_BASE_URL[chainId as EvmChainId]
 
     if (!baseAPI) {
       return null

--- a/libs/repositories/src/repos/TokenHolderRepository/TokenHolderRepositoryGoldRush.ts
+++ b/libs/repositories/src/repos/TokenHolderRepository/TokenHolderRepositoryGoldRush.ts
@@ -1,4 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { EvmChainId } from '@cowprotocol/shared'
 import { injectable } from 'inversify'
 import { GOLD_RUSH_API_BASE_URL, GOLD_RUSH_API_KEY, GOLD_RUSH_CLIENT_NETWORK_MAPPING } from '../../datasources/goldRush'
 import { TokenHolderPoint, TokenHolderRepository } from './TokenHolderRepository'
@@ -37,7 +38,7 @@ interface GoldRushTokenHoldersResponse {
 @injectable()
 export class TokenHolderRepositoryGoldRush implements TokenHolderRepository {
   async getTopTokenHolders(chainId: SupportedChainId, tokenAddress: string): Promise<TokenHolderPoint[] | null> {
-    const network = GOLD_RUSH_CLIENT_NETWORK_MAPPING[chainId]
+    const network = GOLD_RUSH_CLIENT_NETWORK_MAPPING[chainId as EvmChainId]
     if (!network) {
       return null
     }

--- a/libs/repositories/src/repos/TokenHolderRepository/TokenHolderRepositoryMoralis.ts
+++ b/libs/repositories/src/repos/TokenHolderRepository/TokenHolderRepositoryMoralis.ts
@@ -1,4 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { EvmChainId } from '@cowprotocol/shared'
 import { injectable } from 'inversify'
 import { MORALIS_API_BASE_URL, MORALIS_API_KEY, MORALIS_CLIENT_NETWORK_MAPPING } from '../../datasources/moralis'
 import { TokenHolderPoint, TokenHolderRepository } from './TokenHolderRepository'
@@ -25,7 +26,7 @@ interface MoralisTokenHoldersResponse {
 @injectable()
 export class TokenHolderRepositoryMoralis implements TokenHolderRepository {
   async getTopTokenHolders(chainId: SupportedChainId, tokenAddress: string): Promise<TokenHolderPoint[] | null> {
-    const network = MORALIS_CLIENT_NETWORK_MAPPING[chainId]
+    const network = MORALIS_CLIENT_NETWORK_MAPPING[chainId as EvmChainId]
     if (!network) {
       return null
     }

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryCow.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryCow.ts
@@ -1,5 +1,5 @@
-import { isSupportedChain, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { logger } from '@cowprotocol/shared'
+import { isEvmChain, isSupportedChain } from '@cowprotocol/cow-sdk'
+import { EvmChainId, logger } from '@cowprotocol/shared'
 import { BigNumber } from 'bignumber.js'
 import { injectable } from 'inversify'
 
@@ -15,13 +15,14 @@ import { getSupportedCoingeckoChainId } from '../../utils/coingeckoUtils'
 export class UsdRepositoryCow extends UsdRepositoryNoop {
   override name = 'Cow'
 
-  constructor(private cowApiClients: Record<SupportedChainId, CowApiClient>, private erc20Repository: Erc20Repository) {
+  constructor(private cowApiClients: Record<EvmChainId, CowApiClient>, private erc20Repository: Erc20Repository) {
     super()
   }
 
   async getUsdPrice(chainIdOrSlug: string, tokenAddress?: string | undefined): Promise<number | null> {
     const chainId = getSupportedCoingeckoChainId(chainIdOrSlug)
-    if (!chainId || !isSupportedChain(chainId)) {
+    // Solana is a SupportedChainId but this repo has no non-EVM support, so it's excluded explicitly here.
+    if (!chainId || !isSupportedChain(chainId) || !isEvmChain(chainId)) {
       return null
     }
 
@@ -76,7 +77,7 @@ export class UsdRepositoryCow extends UsdRepositoryNoop {
     return usdcPrice.div(tokenPrice).toNumber()
   }
 
-  private async getNativePrice(chainId: SupportedChainId, tokenAddress: string) {
+  private async getNativePrice(chainId: EvmChainId, tokenAddress: string) {
     const cowApiClient = this.cowApiClients[chainId]
     const {
       data: priceResult = {},

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryCow.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryCow.ts
@@ -1,4 +1,4 @@
-import { isEvmChain, isSupportedChain } from '@cowprotocol/cow-sdk'
+import { isSolanaChain, isSupportedChain } from '@cowprotocol/cow-sdk'
 import { EvmChainId, logger } from '@cowprotocol/shared'
 import { BigNumber } from 'bignumber.js'
 import { injectable } from 'inversify'
@@ -21,8 +21,9 @@ export class UsdRepositoryCow extends UsdRepositoryNoop {
 
   async getUsdPrice(chainIdOrSlug: string, tokenAddress?: string | undefined): Promise<number | null> {
     const chainId = getSupportedCoingeckoChainId(chainIdOrSlug)
-    // Solana is a SupportedChainId but this repo has no non-EVM support, so it's excluded explicitly here.
-    if (!chainId || !isSupportedChain(chainId) || !isEvmChain(chainId)) {
+    // CoW API (native_price) only exists for EVM chains with CoW Protocol settlement, so Solana is
+    // excluded here specifically. Solana USD prices are still served via UsdRepositoryCoingecko.
+    if (!chainId || !isSupportedChain(chainId) || isSolanaChain(chainId)) {
       return null
     }
 

--- a/libs/shared/src/const.ts
+++ b/libs/shared/src/const.ts
@@ -6,10 +6,6 @@ import {
 } from '@cowprotocol/cow-sdk'
 import { Address } from 'viem'
 
-/**
- * Chain ids this repo actually supports. All EVM chains in `SupportedChainId`, excluding Solana:
- * this repo has no non-EVM support (no Solana RPC client, contracts, DB schema, etc.).
- */
 export type EvmChainId = Exclude<SupportedChainId, SupportedChainId.SOLANA>
 
 /**

--- a/libs/shared/src/const.ts
+++ b/libs/shared/src/const.ts
@@ -6,6 +6,14 @@ import {
 } from '@cowprotocol/cow-sdk'
 import { Address } from 'viem'
 
+/**
+ * Chain ids with CoW Protocol on-chain settlement infrastructure in this repo (RPC client, contract
+ * addresses, orderbook DB replica, CoW API). Excludes Solana, which has none of that here.
+ *
+ * This does NOT mean Solana is unsupported by the repo in general: USD prices (via CoinGecko) and
+ * price-impact/slippage estimation work for Solana through the general `SupportedChainId`/`AllChainIds`.
+ * Only use this type for the specific EVM/on-chain infra it's scoped to (e.g. `EVM_CHAIN_IDS` below).
+ */
 export type EvmChainId = Exclude<SupportedChainId, SupportedChainId.SOLANA>
 
 /**
@@ -58,6 +66,10 @@ export const COW_API_NETWORK_NAMES = {
   [SupportedChainId.SEPOLIA]: 'sepolia',
 } as const satisfies Record<EvmChainId, string>
 
-export const AllChainIds: EvmChainId[] = ALL_SUPPORTED_CHAIN_IDS.filter(
+// All chains this repo generally knows about, including Solana (used e.g. for USD prices and price-impact estimation).
+export const AllChainIds: SupportedChainId[] = ALL_SUPPORTED_CHAIN_IDS
+
+// Chains with on-chain settlement infra in this repo (RPC client, contracts, orderbook DB, CoW API). No Solana.
+export const EVM_CHAIN_IDS: EvmChainId[] = ALL_SUPPORTED_CHAIN_IDS.filter(
   (chainId): chainId is EvmChainId => chainId !== SupportedChainId.SOLANA
 )

--- a/libs/shared/src/const.ts
+++ b/libs/shared/src/const.ts
@@ -7,6 +7,12 @@ import {
 import { Address } from 'viem'
 
 /**
+ * Chain ids this repo actually supports. All EVM chains in `SupportedChainId`, excluding Solana:
+ * this repo has no non-EVM support (no Solana RPC client, contracts, DB schema, etc.).
+ */
+export type EvmChainId = Exclude<SupportedChainId, SupportedChainId.SOLANA>
+
+/**
  * Native currency address. For example, represents Ether in Mainnet and Arbitrum, and xDAI in Gnosis chain.
  */
 export const NativeCurrencyAddress = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
@@ -39,7 +45,7 @@ export const EXPLORER_NETWORK_NAMES = {
   [SupportedChainId.PLASMA]: 'plasma',
   [SupportedChainId.INK]: 'ink',
   [SupportedChainId.SEPOLIA]: 'sepolia',
-} as const satisfies Record<SupportedChainId, string>
+} as const satisfies Record<EvmChainId, string>
 
 // TODO: Get from SDK
 export const COW_API_NETWORK_NAMES = {
@@ -54,6 +60,8 @@ export const COW_API_NETWORK_NAMES = {
   [SupportedChainId.PLASMA]: 'plasma',
   [SupportedChainId.INK]: 'ink',
   [SupportedChainId.SEPOLIA]: 'sepolia',
-} as const satisfies Record<SupportedChainId, string>
+} as const satisfies Record<EvmChainId, string>
 
-export const AllChainIds: SupportedChainId[] = ALL_SUPPORTED_CHAIN_IDS
+export const AllChainIds: EvmChainId[] = ALL_SUPPORTED_CHAIN_IDS.filter(
+  (chainId): chainId is EvmChainId => chainId !== SupportedChainId.SOLANA
+)

--- a/libs/shared/src/utils/format.ts
+++ b/libs/shared/src/utils/format.ts
@@ -1,6 +1,6 @@
 import { formatUnits } from 'viem'
 
-import { EXPLORER_NETWORK_NAMES } from '../const'
+import { EvmChainId, EXPLORER_NETWORK_NAMES } from '../const'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export function getExplorerUrl(chainId: SupportedChainId, orderUid: string) {
@@ -9,7 +9,7 @@ export function getExplorerUrl(chainId: SupportedChainId, orderUid: string) {
 }
 
 export function getExplorerBaseUrl(chainId: SupportedChainId) {
-  const suffix = chainId === SupportedChainId.MAINNET ? '' : `/${EXPLORER_NETWORK_NAMES[chainId]}`
+  const suffix = chainId === SupportedChainId.MAINNET ? '' : `/${EXPLORER_NETWORK_NAMES[chainId as EvmChainId]}`
   return `https://explorer.cow.fi${suffix}`
 }
 

--- a/libs/shared/src/utils/misc.ts
+++ b/libs/shared/src/utils/misc.ts
@@ -1,6 +1,6 @@
 import { Address, getAddress } from 'viem'
 
-import { AllChainIds, EvmChainId, NativeCurrencyAddress, WrappedNativeTokenAddress } from '../const'
+import { AllChainIds, NativeCurrencyAddress, WrappedNativeTokenAddress } from '../const'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 /**
@@ -16,11 +16,11 @@ export function toTokenAddress(address: string, chainId: SupportedChainId): Addr
   return getAddress(address.toLowerCase())
 }
 
-export function isSupportedChain(chain: number): chain is EvmChainId {
-  return AllChainIds.includes(chain as EvmChainId)
+export function isSupportedChain(chain: number): chain is SupportedChainId {
+  return AllChainIds.includes(chain as SupportedChainId)
 }
 
-export function toSupportedChainId(chain: string | number): EvmChainId {
+export function toSupportedChainId(chain: string | number): SupportedChainId {
   if (typeof chain === 'string') {
     chain = parseInt(chain)
   }

--- a/libs/shared/src/utils/misc.ts
+++ b/libs/shared/src/utils/misc.ts
@@ -1,6 +1,6 @@
 import { Address, getAddress } from 'viem'
 
-import { AllChainIds, NativeCurrencyAddress, WrappedNativeTokenAddress } from '../const'
+import { AllChainIds, EvmChainId, NativeCurrencyAddress, WrappedNativeTokenAddress } from '../const'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 /**
@@ -16,11 +16,11 @@ export function toTokenAddress(address: string, chainId: SupportedChainId): Addr
   return getAddress(address.toLowerCase())
 }
 
-export function isSupportedChain(chain: number): chain is SupportedChainId {
-  return AllChainIds.includes(chain as SupportedChainId)
+export function isSupportedChain(chain: number): chain is EvmChainId {
+  return AllChainIds.includes(chain as EvmChainId)
 }
 
-export function toSupportedChainId(chain: string | number): SupportedChainId {
+export function toSupportedChainId(chain: string | number): EvmChainId {
   if (typeof chain === 'string') {
     chain = parseInt(chain)
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "private": true,
   "dependencies": {
     "@cowprotocol/cms": "^0.3.0-RC.4",
-    "@cowprotocol/cow-sdk": "^9.0.0",
+    "@cowprotocol/cow-sdk": "^9.2.6",
     "@fastify/autoload": "~5.7.1",
     "@fastify/caching": "^8.3.0",
     "@fastify/cors": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,6 +1094,11 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@chainsafe/is-ip@^2.0.1":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/is-ip/-/is-ip-2.1.0.tgz#ba9ac32acd9027698e0b56b91c7af069d28d7931"
+  integrity sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==
+
 "@cowprotocol/cms@^0.3.0-RC.4":
   version "0.3.0-RC.4"
   resolved "https://registry.yarnpkg.com/@cowprotocol/cms/-/cms-0.3.0-RC.4.tgz#cfe28820f88e555891c8fc555814beaf6ba14d46"
@@ -1101,86 +1106,86 @@
   dependencies:
     openapi-fetch "^0.9.3"
 
-"@cowprotocol/cow-sdk@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-9.0.0.tgz#51d97207c191ad6db7b2605b013da29a3d7e8726"
-  integrity sha512-AJ2QpuMTKKTEa+9oCGp0oipWK16aQLpqGDznyHUCrE06qWRTXuqrlHcoFFtGacryvlis/IG2D2d+zFPpH3cI4Q==
+"@cowprotocol/cow-sdk@^9.2.6":
+  version "9.2.6"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-9.2.6.tgz#9681ace899c4d0ccad9e073561afff11920b6201"
+  integrity sha512-OFAd5lTJ5MyTlUmUtOI4kVJTox2Kgsd4TPyzWbRpbJ6pq/NVpiWOYo8d2JcTLZf+N9hI5HvyJn94k5YFzpAl5g==
   dependencies:
-    "@cowprotocol/sdk-app-data" "5.0.0"
-    "@cowprotocol/sdk-common" "0.10.2"
-    "@cowprotocol/sdk-config" "2.0.0"
-    "@cowprotocol/sdk-contracts-ts" "3.0.0"
-    "@cowprotocol/sdk-order-book" "3.0.0"
-    "@cowprotocol/sdk-order-signing" "1.0.0"
-    "@cowprotocol/sdk-trading" "2.0.0"
+    "@cowprotocol/sdk-app-data" "5.3.3"
+    "@cowprotocol/sdk-common" "0.12.1"
+    "@cowprotocol/sdk-config" "2.4.0"
+    "@cowprotocol/sdk-contracts-ts" "3.3.3"
+    "@cowprotocol/sdk-order-book" "4.0.2"
+    "@cowprotocol/sdk-order-signing" "1.1.6"
+    "@cowprotocol/sdk-trading" "2.2.6"
 
-"@cowprotocol/sdk-app-data@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-app-data/-/sdk-app-data-5.0.0.tgz#7375877ff5f3344891d527d08cadff9e11d0f47b"
-  integrity sha512-HGvjV+CbiCSOaoHU7beubaJxFobD8e4v9MliSlc7G48kx2ah6uKJ4SPdsSmGSDmsSfpjmwc8DPihptjNkTidkw==
+"@cowprotocol/sdk-app-data@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-app-data/-/sdk-app-data-5.3.3.tgz#dfcf91b873cc607b335f34c45be06a4d7b330d60"
+  integrity sha512-ZqykzUt09z6jXjLTsqbJ7JUZDVZ3POLjhPhzkkbogAcuEv8vh23oN60MEhDIkLHm65gHbFNN0OR1QbQkKrpNPg==
   dependencies:
-    "@cowprotocol/sdk-common" "0.10.2"
+    "@cowprotocol/sdk-common" "0.12.1"
     ajv "^8.11.0"
     cross-fetch "^3.1.5"
-    ipfs-only-hash "^4.0.0"
+    ipfs-unixfs-importer "^16.1.5"
     json-stringify-deterministic "^1.0.8"
     multiformats "^9.6.4"
 
-"@cowprotocol/sdk-common@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-common/-/sdk-common-0.10.2.tgz#649e4027b5781bf12b700300d22ebd84c0b44d82"
-  integrity sha512-4FrQu6/yCjlI6P5KaBnsfYpu2lNsiyDuPqXrMsj3VgKGAR7+3FddrUE5ojpl82iPLOZzQb9zjFk7+N0UN8V65A==
+"@cowprotocol/sdk-common@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-common/-/sdk-common-0.12.1.tgz#53fed25063692290e4f47a7e7bf6bba1fb89171c"
+  integrity sha512-eh8o2b8iLHNRnS7ATRDNOkISp67KHV7JDzYn1qd/reCVPLlnN/lRDnNomT+A8uPU1aYV2eNkCkbLyTkkQ5bT4g==
   dependencies:
-    "@cowprotocol/sdk-config" "2.0.0"
+    "@cowprotocol/sdk-config" "2.4.0"
 
-"@cowprotocol/sdk-config@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-config/-/sdk-config-2.0.0.tgz#6b8682ee494f0c731c84d1f62a8c75d6a8d9a9cc"
-  integrity sha512-ZeND/fzuzQShpVqOoJ3LbU0DoeKIb2SH2iANumX5LN7R/H495jIfExsb67JANqnrpupJtbUUw1FxfBchN5MVoQ==
+"@cowprotocol/sdk-config@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-config/-/sdk-config-2.4.0.tgz#f25d26f591cc2bdb1aa73e6be0ca2daabdf91d0f"
+  integrity sha512-NMJOqq3LfIjlFFUHd4zbx3Rc3YJl/oCklEaAxw10VHVDNMFMqcdK3tR6W9CPTILR8zAv5DDy1C2cPErXpcrzkQ==
   dependencies:
     exponential-backoff "^3.1.1"
     limiter "^2.1.0"
 
-"@cowprotocol/sdk-contracts-ts@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-contracts-ts/-/sdk-contracts-ts-3.0.0.tgz#58e30c942f598f541ba7a0ac08cb20ad7d5dbbe5"
-  integrity sha512-WQF0tQQE88iucKqb/Y/wYcLPL+ADp2hTeGxEHElBeOJb14VFH6siErIf6shK3SL6ewpBj8nzaa2oJImBYVal4Q==
+"@cowprotocol/sdk-contracts-ts@3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-contracts-ts/-/sdk-contracts-ts-3.3.3.tgz#87a25bed64cd9833ee556430f935fa1dcd3eb8e2"
+  integrity sha512-ejxVq2TJaI5TI6EAJ6kuyjh/3Feob9wHXI+3UpOZ7MJFfX3wDdlb1LTqreC99aKHhjwtBhhYcNm7dYhoLoB1MA==
   dependencies:
-    "@cowprotocol/sdk-common" "0.10.2"
-    "@cowprotocol/sdk-config" "2.0.0"
+    "@cowprotocol/sdk-common" "0.12.1"
+    "@cowprotocol/sdk-config" "2.4.0"
 
-"@cowprotocol/sdk-order-book@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-order-book/-/sdk-order-book-3.0.0.tgz#9c9695ed86b088ddb1258b93d62a26d6965406f8"
-  integrity sha512-tDW3LZK4RnvXtaoUmulU0broirDeZ/Rp1QcVBzIklvBDDUEUcjRavN3sIUdDIOsYJhn6lKsSQTZ7u1MuYRPtDQ==
+"@cowprotocol/sdk-order-book@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-order-book/-/sdk-order-book-4.0.2.tgz#99272b1cbfbf743af7eb2ee9f3c109705ae0fd08"
+  integrity sha512-IuR6LARLtIrfRNkEqgPRkK5/1HRpR3+YktbkfqrH8B3Bi2YzMQxRVxu+N8KtEdC5fbHvkLixKKDDwN2gKAI3bA==
   dependencies:
-    "@cowprotocol/sdk-common" "0.10.2"
-    "@cowprotocol/sdk-config" "2.0.0"
+    "@cowprotocol/sdk-common" "0.12.1"
+    "@cowprotocol/sdk-config" "2.4.0"
     cross-fetch "^3.2.0"
     exponential-backoff "^3.1.2"
     limiter "^3.0.0"
 
-"@cowprotocol/sdk-order-signing@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-order-signing/-/sdk-order-signing-1.0.0.tgz#52695cff7b8229a3ee543948b0f5d3bac702dfa9"
-  integrity sha512-5qY1VpoWwOPK34tqYgi+c2mvP2AjRVS9EaL9szcs+yMSNc62/5rT5DgHqlFHmvt/kR7oJHoejs1CteZvEmMCMw==
+"@cowprotocol/sdk-order-signing@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-order-signing/-/sdk-order-signing-1.1.6.tgz#3e009912190e2481bd355900e16e23a695102ba3"
+  integrity sha512-PyHxKuuuSk9lPRfymTydPGXDoWZEzwzgSgZIenShnPcQDyqyanxroUwV98Vv/zklm4Ah6KxUIZVr/lVmlRg4Hw==
   dependencies:
-    "@cowprotocol/sdk-common" "0.10.2"
-    "@cowprotocol/sdk-config" "2.0.0"
-    "@cowprotocol/sdk-contracts-ts" "3.0.0"
-    "@cowprotocol/sdk-order-book" "3.0.0"
+    "@cowprotocol/sdk-common" "0.12.1"
+    "@cowprotocol/sdk-config" "2.4.0"
+    "@cowprotocol/sdk-contracts-ts" "3.3.3"
+    "@cowprotocol/sdk-order-book" "4.0.2"
 
-"@cowprotocol/sdk-trading@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-trading/-/sdk-trading-2.0.0.tgz#8c6c62a8c41fd7b75402a08098be89f7da2002c2"
-  integrity sha512-h8dEhnuBi2jbKFrbCmByYE8BhH0ir58DXgA/SOHn+1bsiNIqYtTHr/j6eQO7AiSP3fbrYjBOMQPCifFj/xad1A==
+"@cowprotocol/sdk-trading@2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/sdk-trading/-/sdk-trading-2.2.6.tgz#d2819159f26612ca905e1e53617e40fcaad43891"
+  integrity sha512-8B//hK6zaRend2h3X4wZnSM1mfhft3mL8fh7nHX9VYyYgBE0u9URsSJXQ8WsL9SYOFlcQxZU/d9AylUeIOcvtw==
   dependencies:
-    "@cowprotocol/sdk-app-data" "5.0.0"
-    "@cowprotocol/sdk-common" "0.10.2"
-    "@cowprotocol/sdk-config" "2.0.0"
-    "@cowprotocol/sdk-contracts-ts" "3.0.0"
-    "@cowprotocol/sdk-order-book" "3.0.0"
-    "@cowprotocol/sdk-order-signing" "1.0.0"
+    "@cowprotocol/sdk-app-data" "5.3.3"
+    "@cowprotocol/sdk-common" "0.12.1"
+    "@cowprotocol/sdk-config" "2.4.0"
+    "@cowprotocol/sdk-contracts-ts" "3.3.3"
+    "@cowprotocol/sdk-order-book" "4.0.2"
+    "@cowprotocol/sdk-order-signing" "1.1.6"
     deepmerge "^4.3.1"
 
 "@cspotcode/source-map-support@^0.8.0":
@@ -1251,6 +1256,14 @@
     tough-cookie "^4.1.3"
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
+
+"@dnsquery/dns-packet@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz#3abf2c7ebb6dece40a75f429e24f9de23671058a"
+  integrity sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==
+  dependencies:
+    "@leichtgewicht/ip-codec" "^2.0.4"
+    utf8-codec "^1.0.0"
 
 "@esbuild/android-arm64@0.17.19":
   version "0.17.19"
@@ -2017,6 +2030,13 @@
   resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
   integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
 
+"@ipld/dag-pb@^4.1.5":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-pb/-/dag-pb-4.1.7.tgz#8133f099cf0172d41238b23a30355db565d19413"
+  integrity sha512-/i/13trFihjWfDyXlylRwhuYjtzYjvOFw0vlRjYGnZuv7d7MOgA2lV/vRuL5RfeUajM03aZfFLdq4S7cTbbTRg==
+  dependencies:
+    multiformats "^14.0.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz"
@@ -2275,6 +2295,34 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@leichtgewicht/ip-codec@^2.0.4":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
+  integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
+
+"@libp2p/interface@^3.1.0", "@libp2p/interface@^3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@libp2p/interface/-/interface-3.2.5.tgz#fe951a4f864f9012e5b9ae9495ebebdf20c0e4b7"
+  integrity sha512-RdTchTdakBBc4ShKKsvoME/bJYsrCoVDpdYQVdd4TQ30TCb8QwWKGClqAtw7gfLNuaUKm41xz06kASW6AZpbDA==
+  dependencies:
+    "@multiformats/dns" "^1.0.6"
+    "@multiformats/multiaddr" "^13.0.3"
+    main-event "^1.0.1"
+    multiformats "^14.0.0"
+    progress-events "^1.1.0"
+    uint8arraylist "^3.0.2"
+
+"@libp2p/logger@^6.2.4":
+  version "6.2.12"
+  resolved "https://registry.yarnpkg.com/@libp2p/logger/-/logger-6.2.12.tgz#7c60c785b2556d3feb4eba3e755e37046fc46a51"
+  integrity sha512-FwCdJ5hGFDvWI/SULZ4Iez+k+JtdMAj4/EK6bWmkh08ORIztwKpt0IXCOe8nIfKhBKwLYJu00BnZDRsedX7+7Q==
+  dependencies:
+    "@libp2p/interface" "^3.2.5"
+    "@multiformats/multiaddr" "^13.0.3"
+    interface-datastore "^10.0.1"
+    multiformats "^14.0.0"
+    weald "^1.1.0"
+
 "@lukeed/ms@^2.0.1":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.1.tgz"
@@ -2322,10 +2370,34 @@
   resolved "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
-"@multiformats/base-x@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
-  integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
+"@multiformats/dns@^1.0.6":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@multiformats/dns/-/dns-1.0.15.tgz#d0a1bbb2250d31ac53455d882e2007bf2a99a5e3"
+  integrity sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==
+  dependencies:
+    "@dnsquery/dns-packet" "^6.1.1"
+    "@libp2p/interface" "^3.1.0"
+    hashlru "^2.3.0"
+    p-queue "^9.0.0"
+    progress-events "^1.0.0"
+    uint8arrays "^6.1.1"
+
+"@multiformats/multiaddr@^13.0.3":
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz#f33a69879bd817fb67bab8ceb976c5d7dec38e7b"
+  integrity sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==
+  dependencies:
+    "@chainsafe/is-ip" "^2.0.1"
+    multiformats "^14.0.0"
+    uint8-varint "^3.0.0"
+    uint8arrays "^6.1.1"
+
+"@multiformats/murmur3@^2.1.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@multiformats/murmur3/-/murmur3-2.2.8.tgz#48b49d4ea8ca7c065447a58784b938fdfb7904e9"
+  integrity sha512-CrsYnnoWbTYPkLl9D6zKaFPlRbnOekofvi93/1IrXc5eaT5QChRscEFV93kVqHwL2phi8u1hj9UnaeFOq2PYMQ==
+  dependencies:
+    multiformats "^14.0.0"
 
 "@nicolo-ribaudo/semver-v6@^6.3.3":
   version "6.3.3"
@@ -2812,59 +2884,6 @@
   dependencies:
     esquery "^1.4.0"
 
-"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
-  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
-
-"@protobufjs/base64@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
-  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
-
-"@protobufjs/codegen@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
-  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
-
-"@protobufjs/eventemitter@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
-  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
-
-"@protobufjs/fetch@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
-  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.1"
-    "@protobufjs/inquire" "^1.1.0"
-
-"@protobufjs/float@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
-  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
-
-"@protobufjs/inquire@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
-  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
-
-"@protobufjs/path@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
-  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
-
-"@protobufjs/pool@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
-  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
-
-"@protobufjs/utf8@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
-  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
-
 "@redocly/ajv@^8.11.0":
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/@redocly/ajv/-/ajv-8.11.0.tgz#2fad322888dc0113af026e08fceb3e71aae495ae"
@@ -3128,16 +3147,6 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz"
   integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
-"@types/long@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
-  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
-
-"@types/minimist@^1.2.0":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
-  integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
-
 "@types/ms@^0.7.34":
   version "0.7.34"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
@@ -3163,24 +3172,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@>=13.7.0":
-  version "22.15.30"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.30.tgz#3a20431783e28dd0b0326f84ab386a2ec81d921d"
-  integrity sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==
-  dependencies:
-    undici-types "~6.21.0"
-
 "@types/node@^20.14.11":
   version "20.14.11"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.11.tgz#09b300423343460455043ddd4d0ded6ac579b74b"
   integrity sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==
   dependencies:
     undici-types "~5.26.4"
-
-"@types/normalize-package-data@^2.4.0":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
-  integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -3464,6 +3461,11 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
+abort-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/abort-error/-/abort-error-1.0.2.tgz#9fd4b364b3659dadd9ad8af54ec9a1678b51c778"
+  integrity sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==
+
 abstract-cache-redis@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abstract-cache-redis/-/abstract-cache-redis-2.0.0.tgz#ae7e215f0b7dd92cd266797f2702a52be6d3d37f"
@@ -3682,11 +3684,6 @@ arraybuffer.prototype.slice@^1.0.3:
     get-intrinsic "^1.2.3"
     is-array-buffer "^3.0.4"
     is-shared-array-buffer "^1.0.2"
-
-arrify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-  integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
 
 asn1@~0.2.3:
   version "0.2.6"
@@ -3922,10 +3919,18 @@ bl@^5.0.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blakejs@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
-  integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
+blockstore-core@^6.1.2:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/blockstore-core/-/blockstore-core-6.1.3.tgz#d162d0d23cd2e076089225800654f0ecfbc0680e"
+  integrity sha512-GLb6XpvbWOlrz1Liz8lTH8iZoXfJ7otY02i26Ok1q6lDkr9uN3jcZq8GzhNq76jJ7CkFG/EGP8J75F3MFo7v6A==
+  dependencies:
+    "@libp2p/logger" "^6.2.4"
+    interface-blockstore "^6.0.0"
+    interface-store "^7.0.0"
+    it-all "^3.0.9"
+    it-filter "^3.1.4"
+    it-merge "^3.0.12"
+    multiformats "^13.4.2"
 
 bluebird@^3.5.0:
   version "3.7.2"
@@ -4042,15 +4047,6 @@ callsites@^3.0.0:
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camelcase-keys@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
-  integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
-  dependencies:
-    camelcase "^5.3.1"
-    map-obj "^4.0.0"
-    quick-lru "^4.0.1"
-
 camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz"
@@ -4112,16 +4108,6 @@ ci-info@^3.2.0:
   version "3.8.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
-
-cids@^1.0.0, cids@^1.1.5, cids@^1.1.6:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/cids/-/cids-1.1.9.tgz#402c26db5c07059377bcd6fb82f2a24e7f2f4a4f"
-  integrity sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==
-  dependencies:
-    multibase "^4.0.1"
-    multicodec "^3.0.1"
-    multihashes "^4.0.1"
-    uint8arrays "^3.0.0"
 
 cjs-module-lexer@^1.0.0:
   version "1.2.3"
@@ -4460,19 +4446,6 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-decamelize-keys@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.1.tgz#04a2d523b2f18d80d0158a43b895d56dff8d19d8"
-  integrity sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==
-  dependencies:
-    decamelize "^1.1.0"
-    map-obj "^1.0.0"
-
-decamelize@^1.1.0, decamelize@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-  integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
-
 decimal.js-light@^2.5.0:
   version "2.5.1"
   resolved "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz"
@@ -4680,11 +4653,6 @@ env-schema@^5.0.0:
     ajv "^8.0.0"
     dotenv "^16.0.0"
     dotenv-expand "^9.0.0"
-
-err-code@^3.0.0, err-code@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/err-code/-/err-code-3.0.1.tgz#a444c7b992705f2b120ee320b09972eef331c920"
-  integrity sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -5054,6 +5022,11 @@ eventemitter3@^3.0.0:
   version "3.1.2"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
+eventemitter3@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
 
 events@^3.3.0:
   version "3.3.0"
@@ -5679,18 +5652,13 @@ graphemer@^1.4.0:
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-hamt-sharding@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/hamt-sharding/-/hamt-sharding-2.0.1.tgz#f45686d0339e74b03b233bee1bde9587727129b6"
-  integrity sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==
+hamt-sharding@^3.0.6:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/hamt-sharding/-/hamt-sharding-3.0.8.tgz#4d63f08804ec94296988e2cc4d9dc27f5ac32396"
+  integrity sha512-pEh4hYa4ZyDJ2jWBTz7MVqTTGC3va3iEIMDJfbCKskR9rzHRd8HVwUyH5nLiLxK6VCFWIJ4vnlAEn4Hwx49Rbg==
   dependencies:
     sparse-array "^1.3.1"
-    uint8arrays "^3.0.0"
-
-hard-rejection@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
-  integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
+    uint8arrays "^6.1.1"
 
 harmony-reflect@^1.4.6:
   version "1.6.2"
@@ -5751,6 +5719,11 @@ hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+hashlru@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/hashlru/-/hashlru-2.3.0.tgz#5dc15928b3f6961a2056416bb3a4910216fdfb51"
+  integrity sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==
+
 hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
@@ -5789,18 +5762,6 @@ hmac-drbg@^1.0.1:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hosted-git-info@^2.1.4:
-  version "2.8.9"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
-  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
-
-hosted-git-info@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
-  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
-  dependencies:
-    lru-cache "^6.0.0"
 
 html-encoding-sniffer@^4.0.0:
   version "4.0.0"
@@ -5913,11 +5874,6 @@ imurmurhash@^0.1.4:
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
-
 index-to-position@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/index-to-position/-/index-to-position-0.1.2.tgz#e11bfe995ca4d8eddb1ec43274488f3c201a7f09"
@@ -5936,14 +5892,34 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-interface-ipld-format@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/interface-ipld-format/-/interface-ipld-format-1.0.1.tgz#bee39c70c584a033e186ff057a2be89f215963e3"
-  integrity sha512-WV/ar+KQJVoQpqRDYdo7YPGYIUHJxCuOEhdvsRpzLqoOIVCqPKdMMYmsLL1nCRsF3yYNio+PAJbCKiv6drrEAg==
+interface-blockstore@^6.0.0, interface-blockstore@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/interface-blockstore/-/interface-blockstore-6.0.2.tgz#bbd21d2334fca0f89b75956cfd4ceedda39032fa"
+  integrity sha512-Z8LscLfuNWYatKVgaEXK8su+wY6iEEcCXYQiwXf20XVuMvR/zyFa6A0s36epfw8CvUrIv+bXT+FZ2hMEfUCmJw==
   dependencies:
-    cids "^1.1.6"
-    multicodec "^3.0.1"
-    multihashes "^4.0.2"
+    interface-store "^7.0.0"
+    multiformats "^13.4.2"
+
+interface-datastore@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/interface-datastore/-/interface-datastore-10.0.1.tgz#d4dbc0ffef74f2b0cd90b32f7691a5a4dee66de7"
+  integrity sha512-DYMj/Og5Cz1Qwkx6/x5KRvR8SYEX7rVAv3KKCm2NzTwWSfpNAC4PahjcYbHyoZBP6zPWrhQv5n5wE+vaDdgSAg==
+  dependencies:
+    abort-error "^1.0.2"
+    interface-store "^8.0.0"
+    uint8arrays "^6.1.1"
+
+interface-store@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/interface-store/-/interface-store-7.0.2.tgz#77b4a2cc426757cb7aa1745f4bacb14c17ea1c63"
+  integrity sha512-KYOPcDH+1peaPhSeoZujR5nwkVeola1EdrnrlHTIM0HRNUs9B0aTsUQMH5kTmIjaQq1BOowoUyoCamgL8IMyww==
+
+interface-store@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/interface-store/-/interface-store-8.0.0.tgz#2a6d8c5a300c0da272e9ff44038958082aa591a1"
+  integrity sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==
+  dependencies:
+    abort-error "^1.0.2"
 
 internal-slot@^1.0.7:
   version "1.0.7"
@@ -5996,54 +5972,35 @@ ipaddr.js@1.9.1:
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-ipfs-only-hash@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ipfs-only-hash/-/ipfs-only-hash-4.0.0.tgz#b3bd60a244d9eb7394961aa9d812a2e5ac7c04d6"
-  integrity sha512-TE1DZCvfw8i3gcsTq3P4TFx3cKFJ3sluu/J3XINkJhIN9OwJgNMqKA+WnKx6ByCb1IoPXsTp1KM7tupElb6SyA==
+ipfs-unixfs-importer@^16.1.5:
+  version "16.1.5"
+  resolved "https://registry.yarnpkg.com/ipfs-unixfs-importer/-/ipfs-unixfs-importer-16.1.5.tgz#fef147a800d33883a6252631402a832b8baace94"
+  integrity sha512-w/voTDW5gt5RlZlJ/EljU4q4s+4any2LZ+10UJR7i24+xWWv1+ReyaC9dz46U6HB5YqztAKCzBB123OOsDsNFg==
   dependencies:
-    ipfs-unixfs-importer "^7.0.1"
-    meow "^9.0.0"
+    "@ipld/dag-pb" "^4.1.5"
+    "@multiformats/murmur3" "^2.1.8"
+    blockstore-core "^6.1.2"
+    hamt-sharding "^3.0.6"
+    interface-blockstore "^6.0.1"
+    interface-store "^7.0.0"
+    ipfs-unixfs "^12.0.0"
+    it-all "^3.0.9"
+    it-batch "^3.0.9"
+    it-first "^3.0.9"
+    it-parallel-batch "^3.0.9"
+    multiformats "^13.3.7"
+    progress-events "^1.0.1"
+    rabin-wasm "^0.1.5"
+    uint8arraylist "^2.4.8"
+    uint8arrays "^5.1.0"
 
-ipfs-unixfs-importer@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/ipfs-unixfs-importer/-/ipfs-unixfs-importer-7.0.3.tgz#b850e831ca9647d589ef50bc33421f65bab7bba6"
-  integrity sha512-qeFOlD3AQtGzr90sr5Tq1Bi8pT5Nr2tSI8z310m7R4JDYgZc6J1PEZO3XZQ8l1kuGoqlAppBZuOYmPEqaHcVQQ==
+ipfs-unixfs@^12.0.0:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/ipfs-unixfs/-/ipfs-unixfs-12.0.2.tgz#a8d9164c122fced1818d69c93bc0e185b34bd392"
+  integrity sha512-uZ3rutVVZZ+tw52P+sgDSgOSK6ztExJVlfCjKvSD+NIEVlWQPDeKgdSFm+Kxchmgp7t6g1h+dzir+NgY+VsQXg==
   dependencies:
-    bl "^5.0.0"
-    cids "^1.1.5"
-    err-code "^3.0.1"
-    hamt-sharding "^2.0.0"
-    ipfs-unixfs "^4.0.3"
-    ipld-dag-pb "^0.22.2"
-    it-all "^1.0.5"
-    it-batch "^1.0.8"
-    it-first "^1.0.6"
-    it-parallel-batch "^1.0.9"
-    merge-options "^3.0.4"
-    multihashing-async "^2.1.0"
-    rabin-wasm "^0.1.4"
-    uint8arrays "^2.1.2"
-
-ipfs-unixfs@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz#7c43e5726052ade4317245358ac541ef3d63d94e"
-  integrity sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==
-  dependencies:
-    err-code "^3.0.1"
-    protobufjs "^6.10.2"
-
-ipld-dag-pb@^0.22.2:
-  version "0.22.3"
-  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.22.3.tgz#6d5af28b5752236a5cb0e0a1888c87dd733b55cd"
-  integrity sha512-dfG5C5OVAR4FEP7Al2CrHWvAyIM7UhAQrjnOYOIxXGQz5NlEj6wGX0XQf6Ru6or1na6upvV3NQfstapQG8X2rg==
-  dependencies:
-    cids "^1.0.0"
-    interface-ipld-format "^1.0.0"
-    multicodec "^3.0.1"
-    multihashing-async "^2.0.0"
-    protobufjs "^6.10.2"
-    stable "^0.1.8"
-    uint8arrays "^2.0.5"
+    protons-runtime "^6.0.1"
+    uint8arraylist "^2.4.8"
 
 is-array-buffer@^3.0.4:
   version "3.0.4"
@@ -6091,13 +6048,6 @@ is-core-module@^2.1.0, is-core-module@^2.11.0:
   integrity sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==
   dependencies:
     has "^1.0.3"
-
-is-core-module@^2.16.0, is-core-module@^2.5.0:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
-  integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
-  dependencies:
-    hasown "^2.0.2"
 
 is-data-view@^1.0.1:
   version "1.0.1"
@@ -6157,15 +6107,10 @@ is-number@^7.0.0:
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-plain-obj@^1.1, is-plain-obj@^1.1.0:
+is-plain-obj@^1.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
-
-is-plain-obj@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
-  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -6309,27 +6254,55 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-it-all@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/it-all/-/it-all-1.0.6.tgz#852557355367606295c4c3b7eff0136f07749335"
-  integrity sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==
+it-all@^3.0.9:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/it-all/-/it-all-3.0.11.tgz#9c3e7b640c871ada270a18fbb7dee26aa0c70fd7"
+  integrity sha512-Gvqj6MO4GMLnFdtE68HZRpGBskNC+9+GQ+JevTGNYLyhjUuPhjDLU3jN1LpBemXJDW1bRSkczqA/qGyKlPKrcQ==
 
-it-batch@^1.0.8, it-batch@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/it-batch/-/it-batch-1.0.9.tgz#7e95aaacb3f9b1b8ca6c8b8367892171d6a5b37f"
-  integrity sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA==
+it-batch@^3.0.0, it-batch@^3.0.9:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/it-batch/-/it-batch-3.0.11.tgz#4a54c4b04d6dfa6ca98900d31c8888c9733cd00c"
+  integrity sha512-2bvKErkXhtwKYDLKAGdEgveOs8wB0i3RItbaroP/6cC/QlrM7j+HAq/yJq6ci4J7KnzdRi76GyipKlafdOTBgw==
 
-it-first@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/it-first/-/it-first-1.0.7.tgz#a4bef40da8be21667f7d23e44dae652f5ccd7ab1"
-  integrity sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g==
-
-it-parallel-batch@^1.0.9:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/it-parallel-batch/-/it-parallel-batch-1.0.11.tgz#f889b4e1c7a62ef24111dbafbaaa010b33d00f69"
-  integrity sha512-UWsWHv/kqBpMRmyZJzlmZeoAMA0F3SZr08FBdbhtbe+MtoEBgr/ZUAKrnenhXCBrsopy76QjRH2K/V8kNdupbQ==
+it-filter@^3.1.4:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/it-filter/-/it-filter-3.1.6.tgz#9dc2fb545bdaa6c3751961fa767aba6fa9cbd8d4"
+  integrity sha512-yXiGPAvJn/exXjVFSCMQc3+J/7RLpOMwKoY2DH1yMhF4lYkdRoAdOwU0vnDACAlRAexf7AZvESZIc9mzhEoi/A==
   dependencies:
-    it-batch "^1.0.9"
+    it-peekable "^3.0.0"
+
+it-first@^3.0.9:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/it-first/-/it-first-3.0.11.tgz#e59f9659ceb20b8fc1f2d862106fe24f9ce84f47"
+  integrity sha512-0ig8DKpg09V1o7JBagm3oPx3VY7WYfU5w3lpbLbqzijnfMPSvMGoMZuLm17h/RgOJXKP+9mt7vsCNiU2TW8TkQ==
+
+it-merge@^3.0.12:
+  version "3.0.15"
+  resolved "https://registry.yarnpkg.com/it-merge/-/it-merge-3.0.15.tgz#5b1e31bf894599cda4c706628e464340841d5597"
+  integrity sha512-rUskoyECUdJsUwpfBtiLXddm56J+vukMztq+PpfTss1mRl/aHv1YJs+6Q2XnpvDThFC2y4Xm636X0xh6IecPGg==
+  dependencies:
+    it-queueless-pushable "^2.0.0"
+
+it-parallel-batch@^3.0.9:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/it-parallel-batch/-/it-parallel-batch-3.0.11.tgz#f4d33b9866f257361816fdaf890e7e1979193e5e"
+  integrity sha512-n2gvHRVx14COn25jkio+fOHuKWaA5EVf9f0GbdWgVe8gXRIMYCai+CbmQACIv7o2Jn3ZAUOXD9Ob1Ftod0qtJQ==
+  dependencies:
+    it-batch "^3.0.0"
+
+it-peekable@^3.0.0:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/it-peekable/-/it-peekable-3.0.10.tgz#bd4be5de24cf1d052cab4b0e89618991908000a0"
+  integrity sha512-2E6+p1pelZOhzp69aaiiBuEybWzAl10uYbIdCR3Pxy8bFNnS/kgpbLtGbNbIZ6RVdU7yHHkmATYwjy52GfFEKA==
+
+it-queueless-pushable@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/it-queueless-pushable/-/it-queueless-pushable-2.0.5.tgz#893a8e0282f8d5b02239b0075fe594b9776296ed"
+  integrity sha512-BaKqGLL1AQMR1AEaxiM09vzJQVXHHhfhh9UV0qPqORw/8Rm8igDQqT1qHregfHIb1NIW9jxQ/aXBibHJyuivuQ==
+  dependencies:
+    abort-error "^1.0.2"
+    p-defer "^4.0.1"
+    race-signal "^2.0.0"
 
 jake@^10.8.5:
   version "10.8.7"
@@ -6880,11 +6853,6 @@ just-performance@4.3.0:
   resolved "https://registry.yarnpkg.com/just-performance/-/just-performance-4.3.0.tgz#cc2bc8c9227f09e97b6b1df4cd0de2df7ae16db1"
   integrity sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q==
 
-kind-of@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
-  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
-
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz"
@@ -7004,11 +6972,6 @@ lodash@^4.17.15, lodash@^4.17.21, lodash@~4.17.15:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-
 lru-cache@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -7032,6 +6995,11 @@ lru_map@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
+main-event@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/main-event/-/main-event-1.0.5.tgz#956db3cd0d730cc96df9440e4da78a2519702ce9"
+  integrity sha512-4l9z8r7Q446mhhVTwdHmfPksOYBwN2xa7ewEW2yxPVNQapIaAf57ORFLMB91SpMEMa4wXowect7fq3uMLjDnGA==
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -7057,16 +7025,6 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-map-obj@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-  integrity sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==
-
-map-obj@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
-  integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
-
 marked@^15.0.10:
   version "15.0.10"
   resolved "https://registry.yarnpkg.com/marked/-/marked-15.0.10.tgz#466f718a312ef83c7560ae05e4f8092b21e3c48b"
@@ -7077,37 +7035,12 @@ media-typer@0.3.0:
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-meow@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"
-  integrity sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==
-  dependencies:
-    "@types/minimist" "^1.2.0"
-    camelcase-keys "^6.2.2"
-    decamelize "^1.2.0"
-    decamelize-keys "^1.1.0"
-    hard-rejection "^2.1.0"
-    minimist-options "4.1.0"
-    normalize-package-data "^3.0.0"
-    read-pkg-up "^7.0.1"
-    redent "^3.0.0"
-    trim-newlines "^3.0.0"
-    type-fest "^0.18.0"
-    yargs-parser "^20.2.3"
-
 merge-options@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-1.0.1.tgz#2a64b24457becd4e4dc608283247e94ce589aa32"
   integrity sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==
   dependencies:
     is-plain-obj "^1.1"
-
-merge-options@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
-  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
-  dependencies:
-    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -7154,11 +7087,6 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-min-indent@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
-  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
-
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
@@ -7197,15 +7125,6 @@ minimatch@^9.0.0:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist-options@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
-  integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
-  dependencies:
-    arrify "^1.0.1"
-    is-plain-obj "^1.1.0"
-    kind-of "^6.0.3"
-
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -7238,56 +7157,30 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+ms@^4.0.0-nightly.202508271359:
+  version "4.0.0-nightly.202508271359"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-4.0.0-nightly.202508271359.tgz#8ece37f3e9335e111417e5eecd1e4e89a904b6ad"
+  integrity sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==
+
 muggle-string@^0.3.1:
   version "0.3.1"
   resolved "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz"
   integrity sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==
 
-multibase@^4.0.1:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/multibase/-/multibase-4.0.6.tgz#6e624341483d6123ca1ede956208cb821b440559"
-  integrity sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==
-  dependencies:
-    "@multiformats/base-x" "^4.0.1"
+multiformats@^13.0.0, multiformats@^13.3.7, multiformats@^13.4.2:
+  version "13.4.2"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-13.4.2.tgz#309ee17d3946db9a6954cf6832aeb2b4b10dd0f3"
+  integrity sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==
 
-multicodec@^3.0.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-3.2.1.tgz#82de3254a0fb163a107c1aab324f2a91ef51efb2"
-  integrity sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==
-  dependencies:
-    uint8arrays "^3.0.0"
-    varint "^6.0.0"
+multiformats@^14.0.0:
+  version "14.0.5"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-14.0.5.tgz#3d9819edefb885d9029cedcae565fd0a8f3052df"
+  integrity sha512-vbIm83F2yZ1pWJGS0yl0ysracIvv56LtbrIyiIQHoLdYDJOMoLfVFsXhh9DUH4SFdkdkFhucyWniihsNzVEjkQ==
 
-multiformats@^9.4.2, multiformats@^9.6.4:
+multiformats@^9.6.4:
   version "9.9.0"
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.9.0.tgz#c68354e7d21037a8f1f8833c8ccd68618e8f1d37"
   integrity sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==
-
-multihashes@^4.0.1, multihashes@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-4.0.3.tgz#426610539cd2551edbf533adeac4c06b3b90fb05"
-  integrity sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==
-  dependencies:
-    multibase "^4.0.1"
-    uint8arrays "^3.0.0"
-    varint "^5.0.2"
-
-multihashing-async@^2.0.0, multihashing-async@^2.1.0:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/multihashing-async/-/multihashing-async-2.1.4.tgz#26dce2ec7a40f0e7f9e732fc23ca5f564d693843"
-  integrity sha512-sB1MiQXPSBTNRVSJc2zM157PXgDtud2nMFUEIvBrsq5Wv96sUclMRK/ecjoP1T/W61UJBqt4tCTwMkUpt2Gbzg==
-  dependencies:
-    blakejs "^1.1.0"
-    err-code "^3.0.0"
-    js-sha3 "^0.8.0"
-    multihashes "^4.0.1"
-    murmurhash3js-revisited "^3.0.0"
-    uint8arrays "^3.0.0"
-
-murmurhash3js-revisited@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz#6bd36e25de8f73394222adc6e41fa3fac08a5869"
-  integrity sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==
 
 mustache@^4.2.0:
   version "4.2.0"
@@ -7387,26 +7280,6 @@ node-telegram-bot-api@^0.65.1:
     file-type "^3.9.0"
     mime "^1.6.0"
     pump "^2.0.0"
-
-normalize-package-data@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
-  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
-  dependencies:
-    hosted-git-info "^2.1.4"
-    resolve "^1.10.0"
-    semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
-
-normalize-package-data@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e"
-  integrity sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
-  dependencies:
-    hosted-git-info "^4.0.1"
-    is-core-module "^2.5.0"
-    semver "^7.3.4"
-    validate-npm-package-license "^3.0.1"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -7656,6 +7529,11 @@ ox@0.9.6:
     abitype "^1.0.9"
     eventemitter3 "5.0.1"
 
+p-defer@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-4.0.1.tgz#d12c6d41420785ed0d162dbd86b71ba490f7f99e"
+  integrity sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==
+
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz"
@@ -7688,6 +7566,19 @@ p-map@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
+p-queue@^9.0.0:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-9.3.3.tgz#c5e528c7eb361b7ba8eb5a9406902f7f2e75fc8f"
+  integrity sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==
+  dependencies:
+    eventemitter3 "^5.0.4"
+    p-timeout "^7.0.0"
+
+p-timeout@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-7.0.1.tgz#95680a6aa693c530f14ac337b8bd32d4ec6ae4f0"
+  integrity sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -8066,6 +7957,11 @@ process@^0.11.10:
   resolved "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
+progress-events@^1.0.0, progress-events@^1.0.1, progress-events@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/progress-events/-/progress-events-1.1.0.tgz#32c5c3cbce3d6465a31ca088e088aef8a44841df"
+  integrity sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz"
@@ -8074,24 +7970,14 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-protobufjs@^6.10.2:
-  version "6.11.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.4.tgz#29a412c38bf70d89e537b6d02d904a6f448173aa"
-  integrity sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==
+protons-runtime@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/protons-runtime/-/protons-runtime-6.0.2.tgz#770587d4ffad894378fad3b08beef3f1e58d90e2"
+  integrity sha512-hiyjyANwGcgmzc+tXc1/ZcSZhKnl5MDjaVNWkISHBgadaU0sjTgKIKZMZ62d9J9zlSTyKHCs/osPkQ/3Z+7yeA==
   dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
-    "@types/node" ">=13.7.0"
-    long "^4.0.0"
+    uint8-varint "^2.0.4"
+    uint8arraylist "^2.4.8"
+    uint8arrays "^5.1.0"
 
 proxy-addr@^2.0.7:
   version "2.0.7"
@@ -8164,12 +8050,7 @@ quick-format-unescaped@^4.0.3:
   resolved "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz"
   integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
 
-quick-lru@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
-  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
-
-rabin-wasm@^0.1.4:
+rabin-wasm@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/rabin-wasm/-/rabin-wasm-0.1.5.tgz#5b625ca007d6a2cbc1456c78ae71d550addbc9c9"
   integrity sha512-uWgQTo7pim1Rnj5TuWcCewRDTf0PEFTSlaUjWP4eY9EbLV9em08v89oCz/WO+wRxpYuO36XEHp4wgYQnAgOHzA==
@@ -8181,6 +8062,11 @@ rabin-wasm@^0.1.4:
     node-fetch "^2.6.1"
     readable-stream "^3.6.0"
 
+race-signal@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/race-signal/-/race-signal-2.0.2.tgz#be5ddd1fc6bd44663772a67ff7c6bdfa1e99c90a"
+  integrity sha512-IuNNNY5NLriMFEGl3BVei2xq9NIcpkuAklhPWamhu5tRJrJz0w9sloUMz73YXpmUluE2EZocmJm9rpQqXmCPiA==
+
 random-bytes@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/random-bytes/-/random-bytes-1.0.0.tgz#4f68a1dc0ae58bd3fb95848c30324db75d64360b"
@@ -8190,25 +8076,6 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
-read-pkg-up@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
-  integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
-  dependencies:
-    find-up "^4.1.0"
-    read-pkg "^5.2.0"
-    type-fest "^0.8.1"
-
-read-pkg@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
-  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
-  dependencies:
-    "@types/normalize-package-data" "^2.4.0"
-    normalize-package-data "^2.5.0"
-    parse-json "^5.0.0"
-    type-fest "^0.6.0"
 
 "readable-stream@1.x >=1.1.9":
   version "1.1.14"
@@ -8264,14 +8131,6 @@ real-require@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz"
   integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
-
-redent@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
-  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
-  dependencies:
-    indent-string "^4.0.0"
-    strip-indent "^3.0.0"
 
 redis-commands@1.7.0:
   version "1.7.0"
@@ -8411,15 +8270,6 @@ resolve.exports@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz"
   integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
-
-resolve@^1.10.0:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
-  integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
-  dependencies:
-    is-core-module "^2.16.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.12.0, resolve@^1.14.2, resolve@^1.20.0, resolve@~1.22.1:
   version "1.22.2"
@@ -8564,11 +8414,6 @@ secure-json-parse@^2.4.0, secure-json-parse@^2.5.0:
   resolved "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz"
   integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
 
-"semver@2 || 3 || 4 || 5":
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
-
 semver@7.3.4:
   version "7.3.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz"
@@ -8587,11 +8432,6 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.3.4:
-  version "7.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
-  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 semver@~7.3.0:
   version "7.3.8"
@@ -8737,32 +8577,6 @@ spawn-command@^0.0.2-1:
   resolved "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz"
   integrity sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==
 
-spdx-correct@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
-  integrity sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==
-  dependencies:
-    spdx-expression-parse "^3.0.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-exceptions@^2.1.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz#5d607d27fc806f66d7b64a766650fa890f04ed66"
-  integrity sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==
-
-spdx-expression-parse@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
-  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-license-ids@^3.0.0:
-  version "3.0.21"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz#6d6e980c9df2b6fc905343a3b2d702a6239536c3"
-  integrity sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==
-
 split2@^3.0.0:
   version "3.2.2"
   resolved "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz"
@@ -8794,11 +8608,6 @@ sshpk@^1.14.1:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
-
-stable@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
-  integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
 stack-utils@^2.0.3:
   version "2.0.6"
@@ -8923,13 +8732,6 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-indent@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
-  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
-  dependencies:
-    min-indent "^1.0.0"
-
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1, strip-json-comments@~3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
@@ -8943,6 +8745,11 @@ strong-log-transformer@^2.1.0:
     duplexer "^0.1.1"
     minimist "^1.2.0"
     through "^2.3.4"
+
+supports-color@^10.0.0:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-10.2.2.tgz#466c2978cc5cd0052d542a0b576461c2b802ebb4"
+  integrity sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -9136,11 +8943,6 @@ tree-kill@^1.2.2:
   resolved "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-trim-newlines@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
-  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
-
 ts-algebra@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/ts-algebra/-/ts-algebra-1.2.0.tgz"
@@ -9249,11 +9051,6 @@ type-detect@4.0.8:
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.18.0:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
-  integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
-
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
@@ -9263,16 +9060,6 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
-
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 type-fest@^4.7.1:
   version "4.21.0"
@@ -9403,19 +9190,49 @@ uid-safe@^2.1.5:
   dependencies:
     random-bytes "~1.0.0"
 
-uint8arrays@^2.0.5, uint8arrays@^2.1.2:
-  version "2.1.10"
-  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-2.1.10.tgz#34d023c843a327c676e48576295ca373c56e286a"
-  integrity sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==
+uint8-varint@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/uint8-varint/-/uint8-varint-2.0.5.tgz#b7e5af1bc5ff3bc52f913193373f33018c845fda"
+  integrity sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==
   dependencies:
-    multiformats "^9.4.2"
+    uint8arraylist "^2.0.0"
+    uint8arrays "^5.0.0"
 
-uint8arrays@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-3.1.1.tgz#2d8762acce159ccd9936057572dade9459f65ae0"
-  integrity sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==
+uint8-varint@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/uint8-varint/-/uint8-varint-3.0.0.tgz#073d9a1eb24fcb52fae6763511722b7c60b4a951"
+  integrity sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==
   dependencies:
-    multiformats "^9.4.2"
+    uint8arraylist "^3.0.1"
+    uint8arrays "^6.1.0"
+
+uint8arraylist@^2.0.0, uint8arraylist@^2.4.8:
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/uint8arraylist/-/uint8arraylist-2.4.9.tgz#32aaa90d00ac9b4c3985e889f34d0211a06bb9bb"
+  integrity sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==
+  dependencies:
+    uint8arrays "^5.0.1"
+
+uint8arraylist@^3.0.1, uint8arraylist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/uint8arraylist/-/uint8arraylist-3.0.2.tgz#ca67cba700d0aafec34f8f547f40adc3ee769a57"
+  integrity sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==
+  dependencies:
+    uint8arrays "^6.0.0"
+
+uint8arrays@^5.0.0, uint8arrays@^5.0.1, uint8arrays@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-5.1.1.tgz#85b2811d0be22b1b1530f96c6abeb64a718f3f12"
+  integrity sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==
+  dependencies:
+    multiformats "^13.0.0"
+
+uint8arrays@^6.0.0, uint8arrays@^6.1.0, uint8arrays@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-6.1.1.tgz#c2b59dddacc69ac4813ea29ac4b8d727189de522"
+  integrity sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==
+  dependencies:
+    multiformats "^14.0.0"
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -9431,11 +9248,6 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici@^5.19.1:
   version "5.22.1"
@@ -9505,6 +9317,11 @@ url-parse@^1.5.3, url-parse@~1.5.10:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+utf8-codec@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/utf8-codec/-/utf8-codec-1.0.0.tgz#b30252507271cd612dbf5b58f04620a5e1e7bb89"
+  integrity sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==
+
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
@@ -9544,28 +9361,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
-validate-npm-package-license@^3.0.1:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
-  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
-  dependencies:
-    spdx-correct "^3.0.0"
-    spdx-expression-parse "^3.0.0"
-
 validator@^13.7.0:
   version "13.9.0"
   resolved "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz"
   integrity sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==
-
-varint@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/varint/-/varint-5.0.2.tgz#5b47f8a947eb668b848e034dcfa87d0ff8a7f7a4"
-  integrity sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==
-
-varint@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/varint/-/varint-6.0.0.tgz#9881eb0ce8feaea6512439d19ddf84bf551661d0"
-  integrity sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==
 
 vary@^1.1.2:
   version "1.1.2"
@@ -9661,6 +9460,14 @@ walker@^1.0.6, walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+weald@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/weald/-/weald-1.1.3.tgz#73672d8aabac2ca1726f91ab34eaa7c6fb00411c"
+  integrity sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==
+  dependencies:
+    ms "^4.0.0-nightly.202508271359"
+    supports-color "^10.0.0"
 
 web-streams-polyfill@^3.0.3:
   version "3.3.3"
@@ -9834,7 +9641,7 @@ yargs-parser@21.1.1, yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.3:
+yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==


### PR DESCRIPTION
## What changed
- Bumped `@cowprotocol/cow-sdk` 9.0.0 → 9.2.6, which introduced `SupportedChainId.SOLANA`.
- Notification producer is EVM-only (RPC client, contracts, orderbook DB), so it now uses a dedicated `EVM_CHAIN_IDS` constant (`@cowprotocol/shared`) instead of the general `AllChainIds`. The general `AllChainIds`/`isSupportedChain`/`toSupportedChainId` stay Solana-inclusive, since the repo does support Solana elsewhere (USD prices via CoinGecko, price-impact/slippage estimation) — only the on-chain/settlement-specific code (viem clients, CoW API clients, this producer) excludes it.
- Fixed a real regression from the SDK bump: `coingecko.ts`'s Solana → CoinGecko platform mapping was dropped because Solana moved from `AdditionalTargetChainId` to `SupportedChainId` in the new SDK; restored it under its new enum location so Solana USD prices via CoinGecko keep working.
- `UsdRepositoryCow` (CoW's own settlement-API price source, not the CoinGecko one) explicitly excludes Solana via `isSolanaChain`, since `api.cow.fi` has no Solana network — it would otherwise have thrown on an unhandled `chainIdOrSlug`.
- Replaced the hardcoded `env = 'staging'` in `getTradeNotifications.ts`/`ExpiredOrdersNotificationProducer.ts` with a `COW_PROTOCOL_ENV` env var (`prod`/`staging`, defaults to `prod`) that picks the GPv2Settlement contract and eth-flow address to watch.
- Added step-by-step debug/info logging to `TradeNotificationProducer`, `getTradeNotifications`, and `CmsNotificationProducer` (subscribed accounts, block range being indexed, RPC log-query filter and result count, per-order skip reasons). Previously almost everything was `debug`/silent, so a producer that was polling correctly but had nothing to send was indistinguishable from one that was stuck or misconfigured.
- Standardized address handling on the SDK's `getAddressKey()`/`areAddressesEqual()` instead of ad-hoc `.toLowerCase()` comparisons, and fixed two real bugs found during that audit:
  - `getExpiredOrderNotification`: the notification's `account` used the raw `expiredOrder.owner` instead of the already-resolved owner, so expired-order notifications for eth-flow orders were addressed to the eth-flow contract instead of the actual trader.
  - `CmsNotificationProducer`: the subscription filter compared normalized addresses, but the emitted notification kept the raw, un-normalized `account` from the CMS.
- Documented `COW_PROTOCOL_ENV` in `.env.example`.

## Why
Locally, `nx run notification-producer:start` gave no visibility into whether `TradeNotificationProducer`/`CmsNotificationProducer` were working — after the initial startup log there was nothing at `info` level even when everything was healthy, making "quietly working" indistinguishable from "broken." Debugging that surfaced the SDK's new Solana chain id (which broke the build), a hardcoded staging/prod toggle that should be configurable per deployment, and a couple of address-casing bugs that were misrouting eth-flow notifications.

## QA Testing
Reviewer note: this is a headless queue-processing service (no UI), so there's no browser-based preview flow to test.

Developer verification:
- `nx run <app>:build` for `notification-producer`, `api`, `twap`, and `telegram`, plus the affected `test` targets, all pass locally and in CI (docker builds for all four apps + Test and Lint Affected Projects).
- With `LOG_LEVEL=debug` and `COW_PROTOCOL_ENV=staging` set locally, confirmed `TradeNotificationProducer` logs the full per-poll trail (accounts watched, block range, RPC filter, match/skip reasons) against a real Sepolia trade, and via a direct `eth_getTransactionReceipt` check confirmed the trade's `Trade` event only matches once the producer watches the staging settlement contract — validating the new `COW_PROTOCOL_ENV` toggle against real on-chain data, not just types.
