### PR TITLE
refactor: removed duplicated abbreviateAddress in favor of formatAccount

### DIFF
--- a/apps/notification-producer/src/producers/expired-orders/formatExpiredOrderNotification.spec.ts
+++ b/apps/notification-producer/src/producers/expired-orders/formatExpiredOrderNotification.spec.ts
@@ -22,7 +22,7 @@ describe('formatExpiredOrderNotification', () => {
   ])('formats %s order expiry', (orderClass, title, message) => {
     expect(formatExpiredOrderNotification({ ...common, appData: appData(orderClass) })).toEqual({
       title,
-      message: message + '\n\nAccount: 0x1234...7890\nRecipient: 0x0000...0001\nChain: Arbitrum One',
+      message: message + '\n\nAccount: 0x1234…7890\nRecipient: 0x0000…0001\nChain: Arbitrum One',
     })
   })
 })

--- a/apps/notification-producer/src/producers/trade/fromTradeToNotification.spec.ts
+++ b/apps/notification-producer/src/producers/trade/fromTradeToNotification.spec.ts
@@ -41,7 +41,7 @@ describe('fromTradeToNotification', () => {
       })
     ).resolves.toMatchObject({
       title: '✅ Swap filled at 12:42 UTC',
-      message: 'You traded 1 USDC and received 2 COW.\n\nAccount: 0x1234...7890\nChain: Ethereum',
+      message: 'You traded 1 USDC and received 2 COW.\n\nAccount: 0x1234…7890\nChain: Ethereum',
     })
   })
 })

--- a/apps/notification-producer/src/utils/formatOrderNotification.spec.ts
+++ b/apps/notification-producer/src/utils/formatOrderNotification.spec.ts
@@ -14,7 +14,7 @@ describe('formatOrderNotification', () => {
     ).toEqual({
       title: 'Swap expired at 12:42 UTC',
       message:
-        'Your swap to trade 10 USDC → 1 COW has expired.\n\nAccount: 0x1234...7890\nRecipient: 0x0000...0001\nChain: Arbitrum One',
+        'Your swap to trade 10 USDC → 1 COW has expired.\n\nAccount: 0x1234…7890\nRecipient: 0x0000…0001\nChain: Arbitrum One',
     })
   })
 
@@ -29,7 +29,7 @@ describe('formatOrderNotification', () => {
         chainName: 'Arbitrum One',
       })
     ).toMatchObject({
-      message: 'Your order has expired.\n\nAccount: 0xAaaA...aaAa\nChain: Arbitrum One',
+      message: 'Your order has expired.\n\nAccount: 0xAaaA…aaAa\nChain: Arbitrum One',
     })
   })
 })

--- a/apps/notification-producer/src/utils/formatOrderNotification.ts
+++ b/apps/notification-producer/src/utils/formatOrderNotification.ts
@@ -1,4 +1,5 @@
 import { areAddressesEqual } from '@cowprotocol/cow-sdk'
+import { formatAccount } from '@cowprotocol/shared'
 
 export const ORDER_NOTIFICATION_EMOJI = {
   completed: '✅',
@@ -29,14 +30,10 @@ export function formatOrderNotification({
     timeZone: 'UTC',
   })
   const recipientMetadata =
-    recipient && !areAddressesEqual(account, recipient) ? `\nRecipient: ${abbreviateAddress(recipient)}` : ''
+    recipient && !areAddressesEqual(account, recipient) ? `\nRecipient: ${formatAccount(recipient)}` : ''
 
   return {
     title: `${title} at ${time} UTC`,
-    message: `${message}\n\nAccount: ${abbreviateAddress(account)}${recipientMetadata}\nChain: ${chainName}`,
+    message: `${message}\n\nAccount: ${formatAccount(account)}${recipientMetadata}\nChain: ${chainName}`,
   }
-}
-
-function abbreviateAddress(address: string): string {
-  return `${address.slice(0, 6)}...${address.slice(-4)}`
 }

--- a/apps/notification-producer/src/utils/formatTradeNotification.spec.ts
+++ b/apps/notification-producer/src/utils/formatTradeNotification.spec.ts
@@ -16,21 +16,21 @@ describe('formatTradeNotification', () => {
   it('routes a market order by its semantic class', () => {
     expect(formatTradeNotification({ ...common, orderClass: 'market' })).toEqual({
       title: '✅ Swap filled at 12:42 UTC',
-      message: 'You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234...7890\nChain: Arbitrum One',
+      message: 'You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234…7890\nChain: Arbitrum One',
     })
   })
 
   it('formats a swap notification', () => {
     expect(formatTradeNotification({ ...common, orderClass: 'market' })).toEqual({
       title: '✅ Swap filled at 12:42 UTC',
-      message: 'You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234...7890\nChain: Arbitrum One',
+      message: 'You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234…7890\nChain: Arbitrum One',
     })
   })
 
   it('uses a neutral title when a limit order snapshot is unavailable', () => {
     expect(formatTradeNotification({ ...common, orderClass: 'limit' })).toEqual({
       title: 'Limit order update at 12:42 UTC',
-      message: 'You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234...7890\nChain: Arbitrum One',
+      message: 'You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234…7890\nChain: Arbitrum One',
     })
   })
 
@@ -44,7 +44,7 @@ describe('formatTradeNotification', () => {
     ).toEqual({
       title: '✅ Swap filled at 12:42 UTC',
       message:
-        'You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234...7890\nRecipient: 0x0000...0001\nChain: Arbitrum One',
+        'You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234…7890\nRecipient: 0x0000…0001\nChain: Arbitrum One',
     })
   })
 
@@ -58,7 +58,7 @@ describe('formatTradeNotification', () => {
       })
     ).toEqual({
       title: '✅ Swap filled at 12:42 UTC',
-      message: 'You traded 10 USDC and received 1 COW.\n\nAccount: 0xAaaA...aaAa\nChain: Arbitrum One',
+      message: 'You traded 10 USDC and received 1 COW.\n\nAccount: 0xAaaA…aaAa\nChain: Arbitrum One',
     })
   })
 
@@ -81,7 +81,7 @@ describe('formatTradeNotification', () => {
     ).toEqual({
       title: '✅ Limit order filled at 12:42 UTC',
       message:
-        'Your limit order to trade 1000 USDC → 100000 COW is now 100% filled. You received 100001 COW.\n\nAccount: 0x1234...7890\nChain: Arbitrum One',
+        'Your limit order to trade 1000 USDC → 100000 COW is now 100% filled. You received 100001 COW.\n\nAccount: 0x1234…7890\nChain: Arbitrum One',
     })
   })
 
@@ -103,7 +103,7 @@ describe('formatTradeNotification', () => {
     ).toEqual({
       title: '⏳ Limit order partially filled at 12:42 UTC',
       message:
-        'Your limit order to trade 100 USDC → 1000 COW is now 53% filled.\n\nAccount: 0x1234...7890\nChain: Arbitrum One',
+        'Your limit order to trade 100 USDC → 1000 COW is now 53% filled.\n\nAccount: 0x1234…7890\nChain: Arbitrum One',
     })
   })
 
@@ -111,7 +111,7 @@ describe('formatTradeNotification', () => {
     expect(formatTradeNotification({ ...common, orderClass: 'twap' })).toEqual({
       title: '✅ A TWAP part filled at 12:42 UTC',
       message:
-        'One part of your TWAP order filled. You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234...7890\nChain: Arbitrum One',
+        'One part of your TWAP order filled. You traded 10 USDC and received 1 COW.\n\nAccount: 0x1234…7890\nChain: Arbitrum One',
     })
   })
 })

--- a/apps/telegram/src/startCommand.ts
+++ b/apps/telegram/src/startCommand.ts
@@ -4,10 +4,10 @@ import {
   releaseConnectToken,
   PushSubscriptionsRepository,
 } from '@cowprotocol/repositories'
-import { logger } from '@cowprotocol/shared'
+import { formatAccount, logger } from '@cowprotocol/shared'
 import TelegramBot from 'node-telegram-bot-api'
 
-import { formatAccount, UNSUBSCRIBE_MENU_CALLBACK_DATA } from './unsubscribeFlow'
+import { UNSUBSCRIBE_MENU_CALLBACK_DATA } from './unsubscribeFlow'
 
 const START_COMMAND_PATTERN = /^\/start(?:\s+(\S+))?/
 

--- a/apps/telegram/src/unsubscribeFlow.ts
+++ b/apps/telegram/src/unsubscribeFlow.ts
@@ -1,5 +1,5 @@
 import { PushSubscriptionsRepository } from '@cowprotocol/repositories'
-import { logger } from '@cowprotocol/shared'
+import { formatAccount, logger } from '@cowprotocol/shared'
 import TelegramBot from 'node-telegram-bot-api'
 
 // Unsubscribing only happens here, from the bot side, since Telegram itself proves which
@@ -21,10 +21,6 @@ export function buildUnsubscribeAccountCallbackData(account: string): string {
 export function parseUnsubscribeAccountCallbackData(data: string | undefined): string | null {
   if (!data || !data.startsWith(UNSUBSCRIBE_ACCOUNT_CALLBACK_PREFIX)) return null
   return data.slice(UNSUBSCRIBE_ACCOUNT_CALLBACK_PREFIX.length)
-}
-
-export function formatAccount(account: string): string {
-  return `${account.slice(0, 6)}…${account.slice(-4)}`
 }
 
 async function unsubscribeAccount(params: {

--- a/libs/shared/src/utils/addresses.ts
+++ b/libs/shared/src/utils/addresses.ts
@@ -1,5 +1,9 @@
 import { Address, getAddress, isAddress } from 'viem'
 
+export function formatAccount(account: string): string {
+  return `${account.slice(0, 6)}…${account.slice(-4)}`
+}
+
 export function parseEthereumAddressList(values: string[]): Address[] {
   const unique = new Set<Address>()
 


### PR DESCRIPTION
# Summary

Address comment https://github.com/cowprotocol/bff/pull/245#discussion_r3815214706

# Testing

Unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification and unsubscribe messages by consistently abbreviating account and recipient addresses with a Unicode ellipsis.
  * Standardized address formatting across trade and order notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->