### PR TITLE
fix(notifications): adjust ssl for readonly DB

### DIFF
--- a/libs/repositories/src/datasources/postgresPlain.ts
+++ b/libs/repositories/src/datasources/postgresPlain.ts
@@ -1,6 +1,8 @@
 import { ensureEnvs } from '@cowprotocol/shared'
 import { Pool } from 'pg'
 
+const isProduction = process.env.NODE_ENV === 'production'
+
 const REQUIRED_ENVS = ['DATABASE_USERNAME', 'DATABASE_HOST', 'DATABASE_NAME', 'DATABASE_PASSWORD']
 
 export function createNewPostgresPool(): Pool {
@@ -13,6 +15,7 @@ export function createNewPostgresPool(): Pool {
     password: process.env.DATABASE_PASSWORD,
     port: Number(process.env.DATABASE_PORT) || 5432,
     keepAlive: true,
+    ssl: isProduction ? { rejectUnauthorized: false } : undefined,
   })
 
   // Handle connection errors

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cowswap-bff",
   "description": "Backend for frontend is a series of backend services and libraries that enhance user experience for the frontend",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "license": "MIT",
   "scripts": {
     "start": "yarn start:api",


### PR DESCRIPTION
1. We already have the same solution in https://github.com/cowprotocol/bff/blob/cba32d213fa1eeddb064b5e2dbcf3b2d10aa745e/apps/api/src/app/plugins/orm-repositories.ts
2. In theory it could be a vulnerability, but in practice it's impossible because:
 - the DB is readonly
 - the DB is not used for financial functionalities
 - the DB and the BFF are in the same VPC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL connection compatibility in production environments by applying the appropriate secure connection settings.

* **Release**
  * Updated the application version to 0.32.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->