### PR TITLE
fix(getUsdPrice): prevent calling cg/cow when not a token

### DIFF
--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryCoingecko.test.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryCoingecko.test.ts
@@ -51,6 +51,15 @@ describe.skip('UsdRepositoryCoingecko', () => {
       expect(price).toBeGreaterThan(0)
     })
 
+    it('should return NULL for a Solana token requested on Ethereum', async () => {
+      const price = await usdRepositoryCoingecko.getUsdPrice(
+        CHAIN_ID,
+        'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' // USDC on Solana
+      )
+
+      expect(price).toBeNull()
+    })
+
     it('should return the current price without token address', async () => {
       const price = await usdRepositoryCoingecko.getUsdPrice('bitcoin')
 

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.spec.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.spec.ts
@@ -222,17 +222,18 @@ describe('UsdRepositoryCoingecko', () => {
       }
     )
 
-    it.each([WETH, SOLANA_USDC, BTC_CURRENCY_ADDRESS])(
-      'queries repositories for valid token address %s',
-      async (tokenAddress) => {
-        const firstRepository = createRepositoryMock('First')
-        const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository], erc20RepositoryMock)
+    it.each([
+      [WETH, CHAIN_ID],
+      [SOLANA_USDC, SupportedChainId.SOLANA.toString()],
+      [BTC_CURRENCY_ADDRESS, 'bitcoin'],
+    ])('queries repositories for valid token address %s on chain %s', async (tokenAddress, chainIdOrSlug) => {
+      const firstRepository = createRepositoryMock('First')
+      const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository], erc20RepositoryMock)
 
-        await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID, tokenAddress)).resolves.toBe(1)
+      await expect(usdRepositoryFallback.getUsdPrice(chainIdOrSlug, tokenAddress)).resolves.toBe(1)
 
-        expect(firstRepository.getUsdPrice).toHaveBeenCalledWith(CHAIN_ID, tokenAddress)
-      }
-    )
+      expect(firstRepository.getUsdPrice).toHaveBeenCalledWith(chainIdOrSlug, tokenAddress)
+    })
 
     it('queries repositories when the token address is omitted', async () => {
       const firstRepository = createRepositoryMock('First')
@@ -272,6 +273,17 @@ describe('UsdRepositoryCoingecko', () => {
       await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID, WETH)).resolves.toBe(1)
 
       expect(firstRepository.getUsdPrice).toHaveBeenCalledWith(CHAIN_ID, WETH)
+    })
+
+    it('does not query repositories for non-EVM addresses on EVM chains', async () => {
+      const firstRepository = createRepositoryMock('First')
+      const erc20Repository = createErc20RepositoryMock()
+      const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository], erc20Repository)
+
+      await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID, SOLANA_USDC)).resolves.toBeNull()
+
+      expect(erc20Repository.get).not.toHaveBeenCalled()
+      expect(firstRepository.getUsdPrice).not.toHaveBeenCalled()
     })
 
     it('fails open and queries repositories when the existence check throws', async () => {

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.spec.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.spec.ts
@@ -1,9 +1,18 @@
 import { BTC_CURRENCY_ADDRESS, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { logger } from '@cowprotocol/shared'
 import { WETH } from '../../../test/mock'
+import { Erc20, Erc20Repository } from '../Erc20Repository/Erc20Repository'
 import { PricePoint, UsdRepository } from './UsdRepository'
 import { UsdRepositoryFallback } from './UsdRepositoryFallback'
 const mockDate = new Date('2024-01-01T00:00:00Z')
+
+const createErc20RepositoryMock = (
+  erc20: Erc20 | null = { address: WETH, decimals: 18 }
+): jest.Mocked<Erc20Repository> => ({
+  get: jest.fn().mockResolvedValue(erc20),
+})
+
+const erc20RepositoryMock = createErc20RepositoryMock()
 class UsdRepositoryMock_1_1 implements UsdRepository {
   name = 'Mock_1_1'
   async getUsdPrice() {
@@ -74,19 +83,28 @@ const usdRepositoryMock_null_null = new UsdRepositoryMock_null_null()
 describe('UsdRepositoryCoingecko', () => {
   describe('getUsdPrice', () => {
     it('Returns first repo price when is not null', async () => {
-      let usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_1_1, usdRepositoryMock_2_2])
+      let usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_1_1, usdRepositoryMock_2_2],
+        erc20RepositoryMock
+      )
 
       let price = await usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)
 
       expect(price).toEqual(1)
 
-      usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_2_2, usdRepositoryMock_1_1])
+      usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_2_2, usdRepositoryMock_1_1],
+        erc20RepositoryMock
+      )
 
       price = await usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)
 
       expect(price).toEqual(2)
 
-      usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_1_1, usdRepositoryMock_null_3])
+      usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_1_1, usdRepositoryMock_null_3],
+        erc20RepositoryMock
+      )
 
       price = await usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)
       expect(price).toEqual(1)
@@ -94,7 +112,10 @@ describe('UsdRepositoryCoingecko', () => {
 
     it('Returns second repo price when null, and logs the name', async () => {
       const loggerSpy = jest.spyOn(logger, 'info')
-      const usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_null_3, usdRepositoryMock_1_1])
+      const usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_null_3, usdRepositoryMock_1_1],
+        erc20RepositoryMock
+      )
 
       const price = await usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)
       expect(price).toEqual(1)
@@ -104,13 +125,16 @@ describe('UsdRepositoryCoingecko', () => {
     })
 
     it('Returns null when configured with no repositories', async () => {
-      const usdRepositoryFallback = new UsdRepositoryFallback([])
+      const usdRepositoryFallback = new UsdRepositoryFallback([], erc20RepositoryMock)
       const price = await usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)
       expect(price).toEqual(null)
     })
 
     it('Returns null when no repo return a price', async () => {
-      const usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_null_3, usdRepositoryMock_null_null])
+      const usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_null_3, usdRepositoryMock_null_null],
+        erc20RepositoryMock
+      )
       const price = await usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)
       expect(price).toEqual(null)
     })
@@ -118,25 +142,37 @@ describe('UsdRepositoryCoingecko', () => {
 
   describe('getUsdPrices', () => {
     it('Returns first repo prices when is not null', async () => {
-      let usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_1_1, usdRepositoryMock_2_2])
+      let usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_1_1, usdRepositoryMock_2_2],
+        erc20RepositoryMock
+      )
 
       let price = await usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)
       expect(price).toEqual([{ date: mockDate, price: 1, volume: 1 }])
 
-      usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_2_2, usdRepositoryMock_1_1])
+      usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_2_2, usdRepositoryMock_1_1],
+        erc20RepositoryMock
+      )
 
       price = await usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)
 
       expect(price).toEqual([{ date: mockDate, price: 2, volume: 2 }])
 
-      usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_1_1, usdRepositoryMock_null_3])
+      usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_1_1, usdRepositoryMock_null_3],
+        erc20RepositoryMock
+      )
 
       price = await usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)
       expect(price).toEqual([{ date: mockDate, price: 1, volume: 1 }])
     })
 
     it('Returns second repo prices when null', async () => {
-      const usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_null_null, usdRepositoryMock_1_1])
+      const usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_null_null, usdRepositoryMock_1_1],
+        erc20RepositoryMock
+      )
 
       const price = await usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)
       expect(price).toEqual([{ date: mockDate, price: 1, volume: 1 }])
@@ -144,13 +180,16 @@ describe('UsdRepositoryCoingecko', () => {
 
     it('Returns null when configured with no repositories', async () => {
       // When no repo is provided, it returns null
-      const usdRepositoryFallback = new UsdRepositoryFallback([])
+      const usdRepositoryFallback = new UsdRepositoryFallback([], erc20RepositoryMock)
       const price = await usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)
       expect(price).toEqual(null)
     })
 
     it('Returns null when no repo return prices', async () => {
-      const usdRepositoryFallback = new UsdRepositoryFallback([usdRepositoryMock_3_null, usdRepositoryMock_null_null])
+      const usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_3_null, usdRepositoryMock_null_null],
+        erc20RepositoryMock
+      )
       const price = await usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)
       expect(price).toEqual(null)
     })
@@ -168,7 +207,10 @@ describe('UsdRepositoryCoingecko', () => {
       async (tokenAddress) => {
         const firstRepository = createRepositoryMock('First')
         const secondRepository = createRepositoryMock('Second')
-        const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository, secondRepository])
+        const usdRepositoryFallback = new UsdRepositoryFallback(
+          [firstRepository, secondRepository],
+          erc20RepositoryMock
+        )
 
         await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID, tokenAddress)).resolves.toBeNull()
         await expect(usdRepositoryFallback.getUsdPrices(CHAIN_ID, tokenAddress, '5m')).resolves.toBeNull()
@@ -184,7 +226,7 @@ describe('UsdRepositoryCoingecko', () => {
       'queries repositories for valid token address %s',
       async (tokenAddress) => {
         const firstRepository = createRepositoryMock('First')
-        const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository])
+        const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository], erc20RepositoryMock)
 
         await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID, tokenAddress)).resolves.toBe(1)
 
@@ -194,11 +236,78 @@ describe('UsdRepositoryCoingecko', () => {
 
     it('queries repositories when the token address is omitted', async () => {
       const firstRepository = createRepositoryMock('First')
-      const usdRepositoryFallback: UsdRepository = new UsdRepositoryFallback([firstRepository])
+      const usdRepositoryFallback: UsdRepository = new UsdRepositoryFallback([firstRepository], erc20RepositoryMock)
 
       await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID)).resolves.toBe(1)
 
       expect(firstRepository.getUsdPrice).toHaveBeenCalledWith(CHAIN_ID, undefined)
+    })
+  })
+
+  describe('token existence check', () => {
+    const createRepositoryMock = (name: string): jest.Mocked<UsdRepository> => ({
+      name,
+      getUsdPrice: jest.fn().mockResolvedValue(1),
+      getUsdPrices: jest.fn().mockResolvedValue([{ date: mockDate, price: 1, volume: 1 }]),
+    })
+
+    it('does not query repositories when the address is not an ERC20 on the requested chain', async () => {
+      const firstRepository = createRepositoryMock('First')
+      const erc20Repository = createErc20RepositoryMock(null)
+      const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository], erc20Repository)
+
+      await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID, WETH)).resolves.toBeNull()
+      await expect(usdRepositoryFallback.getUsdPrices(CHAIN_ID, WETH, '5m')).resolves.toBeNull()
+
+      expect(erc20Repository.get).toHaveBeenCalledWith(SupportedChainId.MAINNET, WETH)
+      expect(firstRepository.getUsdPrice).not.toHaveBeenCalled()
+      expect(firstRepository.getUsdPrices).not.toHaveBeenCalled()
+    })
+
+    it('queries repositories when the address is an ERC20 on the requested chain', async () => {
+      const firstRepository = createRepositoryMock('First')
+      const erc20Repository = createErc20RepositoryMock()
+      const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository], erc20Repository)
+
+      await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID, WETH)).resolves.toBe(1)
+
+      expect(firstRepository.getUsdPrice).toHaveBeenCalledWith(CHAIN_ID, WETH)
+    })
+
+    it('fails open and queries repositories when the existence check throws', async () => {
+      const firstRepository = createRepositoryMock('First')
+      const erc20Repository: jest.Mocked<Erc20Repository> = {
+        get: jest.fn().mockRejectedValue(new Error('RPC is down')),
+      }
+      const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository], erc20Repository)
+
+      await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID, WETH)).resolves.toBe(1)
+
+      expect(firstRepository.getUsdPrice).toHaveBeenCalledWith(CHAIN_ID, WETH)
+    })
+
+    it.each([SupportedChainId.SOLANA.toString(), '10', 'bitcoin'])(
+      'skips the existence check on chains without an RPC client (%s)',
+      async (chainIdOrSlug) => {
+        const firstRepository = createRepositoryMock('First')
+        const erc20Repository = createErc20RepositoryMock(null)
+        const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository], erc20Repository)
+
+        await expect(usdRepositoryFallback.getUsdPrice(chainIdOrSlug, WETH)).resolves.toBe(1)
+
+        expect(erc20Repository.get).not.toHaveBeenCalled()
+        expect(firstRepository.getUsdPrice).toHaveBeenCalledWith(chainIdOrSlug, WETH)
+      }
+    )
+
+    it('skips the existence check when the token address is omitted', async () => {
+      const firstRepository = createRepositoryMock('First')
+      const erc20Repository = createErc20RepositoryMock(null)
+      const usdRepositoryFallback = new UsdRepositoryFallback([firstRepository], erc20Repository)
+
+      await expect(usdRepositoryFallback.getUsdPrice(CHAIN_ID)).resolves.toBe(1)
+
+      expect(erc20Repository.get).not.toHaveBeenCalled()
     })
   })
 })

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
@@ -1,4 +1,4 @@
-import { BTC_CURRENCY_ADDRESS, isSolanaChain, isSupportedChain } from '@cowprotocol/cow-sdk'
+import { BTC_CURRENCY_ADDRESS, isNonEvmChain, isSupportedChain } from '@cowprotocol/cow-sdk'
 import { logger } from '@cowprotocol/shared'
 import { base58 } from '@scure/base'
 import { injectable } from 'inversify'
@@ -99,7 +99,7 @@ export class UsdRepositoryFallback implements UsdRepository {
 
     // Erc20Repository only has RPC clients for EVM chains with CoW Protocol settlement, so there is
     // nothing to check against for Solana, Bitcoin or Optimism. Same guard as UsdRepositoryCow.
-    if (!chainId || !isSupportedChain(chainId) || isSolanaChain(chainId)) {
+    if (!chainId || !isSupportedChain(chainId) || isNonEvmChain(chainId)) {
       return true
     }
 

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
@@ -1,8 +1,10 @@
-import { BTC_CURRENCY_ADDRESS } from '@cowprotocol/cow-sdk'
+import { BTC_CURRENCY_ADDRESS, isSolanaChain, isSupportedChain } from '@cowprotocol/cow-sdk'
 import { logger } from '@cowprotocol/shared'
 import { base58 } from '@scure/base'
 import { injectable } from 'inversify'
 import { isAddress } from 'viem'
+import { getSupportedCoingeckoChainId } from '../../utils/coingeckoUtils'
+import { Erc20Repository } from '../Erc20Repository/Erc20Repository'
 import { PricePoint, PriceStrategy, UsdRepository } from './UsdRepository'
 
 function isValidTokenAddress(tokenAddress: string | undefined): boolean {
@@ -25,10 +27,14 @@ function isValidTokenAddress(tokenAddress: string | undefined): boolean {
 export class UsdRepositoryFallback implements UsdRepository {
   name = 'Fallback'
 
-  constructor(private usdRepositories: UsdRepository[]) {}
+  constructor(private usdRepositories: UsdRepository[], private erc20Repository: Erc20Repository) {}
 
   async getUsdPrice(chainIdOrSlug: string, tokenAddress?: string): Promise<number | null> {
     if (!isValidTokenAddress(tokenAddress)) {
+      return null
+    }
+
+    if (!(await this.tokenExists(chainIdOrSlug, tokenAddress))) {
       return null
     }
 
@@ -58,6 +64,10 @@ export class UsdRepositoryFallback implements UsdRepository {
       return null
     }
 
+    if (!(await this.tokenExists(chainIdOrSlug, tokenAddress))) {
+      return null
+    }
+
     for (let i = 0; i < this.usdRepositories.length; i++) {
       const usdRepository = this.usdRepositories[i]
       const prices = await usdRepository.getUsdPrices(chainIdOrSlug, tokenAddress, priceStrategy)
@@ -73,5 +83,43 @@ export class UsdRepositoryFallback implements UsdRepository {
       }
     }
     return null
+  }
+
+  /**
+   * An address with no ERC20 contract on the requested chain can't be priced by any source, so we
+   * skip both upstream calls instead of paying for them before returning null anyway.
+   * This is most of the wrong-chain traffic we serve (tokens requested on a chain they don't exist on).
+   */
+  private async tokenExists(chainIdOrSlug: string, tokenAddress: string | undefined): Promise<boolean> {
+    if (!tokenAddress) {
+      return true
+    }
+
+    const chainId = getSupportedCoingeckoChainId(chainIdOrSlug)
+
+    // Erc20Repository only has RPC clients for EVM chains with CoW Protocol settlement, so there is
+    // nothing to check against for Solana, Bitcoin or Optimism. Same guard as UsdRepositoryCow.
+    if (!chainId || !isSupportedChain(chainId) || isSolanaChain(chainId)) {
+      return true
+    }
+
+    try {
+      const erc20 = await this.erc20Repository.get(chainId, tokenAddress)
+
+      if (erc20 === null) {
+        logger.info(`UsdRepositoryFallback: ${tokenAddress} is not an ERC20 on ${chainIdOrSlug}, skipping price lookup`)
+        return false
+      }
+
+      return true
+    } catch (error) {
+      // Fail open: an RPC outage must not take down pricing for tokens the price sources can serve
+      logger.warn(
+        `UsdRepositoryFallback: existence check failed for ${chainIdOrSlug}/${tokenAddress}, continuing: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+      return true
+    }
   }
 }

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
@@ -103,6 +103,12 @@ export class UsdRepositoryFallback implements UsdRepository {
       return true
     }
 
+    // In case a Solana address reaches this step, filter it out keeping only EVM addresses
+    // Solana chain token queries will skip this step entirely so an EVM chain shouldn't check a Solana token
+    if (!isAddress(tokenAddress, { strict: false })) {
+      return false
+    }
+
     try {
       const erc20 = await this.erc20Repository.get(chainId, tokenAddress)
 

--- a/libs/services/src/factories.ts
+++ b/libs/services/src/factories.ts
@@ -97,10 +97,10 @@ export function getUsdRepositoryCoingecko(cacheRepository: CacheRepository): Usd
 }
 
 export function getUsdRepository(cacheRepository: CacheRepository, erc20Repository: Erc20Repository): UsdRepository {
-  return new UsdRepositoryFallback([
-    getUsdRepositoryCoingecko(cacheRepository),
-    getUsdRepositoryCow(cacheRepository, erc20Repository),
-  ])
+  return new UsdRepositoryFallback(
+    [getUsdRepositoryCoingecko(cacheRepository), getUsdRepositoryCow(cacheRepository, erc20Repository)],
+    erc20Repository
+  )
 }
 
 export function getTokenHolderRepositoryEthplorer(cacheRepository: CacheRepository): TokenHolderRepository {


### PR DESCRIPTION
# Summary

Part of https://linear.app/cowswap/issue/FE-449/address-coingecko-fallback-issues-in-bff

Add an existence check in front of the price path. BFF already has a 24h-cached ERC-20 lookup (factories.ts:62-69), so an address with no contract on the requested chain can 404 immediately instead of after two upstream calls. Clears ~84% of our 404s and works without identifying the caller. Highest payoff item.

# Testing

Unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USD price lookups by validating ERC20 token existence before requesting prices.
  * Prevented invalid, nonexistent, or chain-incompatible token addresses from producing misleading price results.
  * Preserved fallback behavior for native tokens, unsupported chains, non-EVM assets, and temporary RPC failures.
* **Tests**
  * Added coverage for valid, missing, and malformed tokens, unsupported chains, omitted addresses, cross-chain mismatches, and RPC errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->