### PR TITLE
fix(getUsdPrice): don't stop of first failure

### DIFF
--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryCache.spec.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryCache.spec.ts
@@ -158,7 +158,11 @@ describe('UsdRepositoryCache', () => {
       const pricePromise = usdRepositoryCache.getUsdPrice(chainId, WETH)
 
       // THEN: The call throws an awful error
-      expect(pricePromise).rejects.toThrow('💥 Booom!')
+      await expect(pricePromise).rejects.toThrow('💥 Booom!')
+
+      // THEN: The failure is NOT cached as "no price". Caching it would hide the outage behind a
+      // 404 for the whole NULL TTL, long after the upstream recovered.
+      expect(redisMock.set).not.toHaveBeenCalled()
     })
   })
 
@@ -277,7 +281,10 @@ describe('UsdRepositoryCache', () => {
       const pricesPromise = usdRepositoryCache.getUsdPrices(chainId, WETH, '5m')
 
       // THEN: The call throws an awful error
-      expect(pricesPromise).rejects.toThrow('💥 Booom!')
+      await expect(pricesPromise).rejects.toThrow('💥 Booom!')
+
+      // THEN: The failure is NOT cached as "no price", same as the single price path
+      expect(redisMock.set).not.toHaveBeenCalled()
     })
   })
 })

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryCoingecko.spec.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryCoingecko.spec.ts
@@ -14,6 +14,17 @@ import { UsdRepositoryCoingecko } from './UsdRepositoryCoingecko'
 
 const okResponse = (data: unknown) => ({ data, response: { status: 200, ok: true } as Response })
 
+const errorResponse = (status: number, statusText = 'Error') => ({
+  data: undefined,
+  response: {
+    status,
+    ok: false,
+    statusText,
+    url: 'https://pro-api.coingecko.com/api/v3/simple/price',
+    text: async () => 'upstream error body',
+  } as unknown as Response,
+})
+
 describe('UsdRepositoryCoingecko', () => {
   let repository: UsdRepositoryCoingecko
 
@@ -105,6 +116,42 @@ describe('UsdRepositoryCoingecko', () => {
           query: { contract_addresses: WETH.toLowerCase(), vs_currencies: 'usd' },
         },
       })
+    })
+  })
+
+  describe('upstream failures vs answers', () => {
+    const chainId = SupportedChainId.MAINNET.toString()
+
+    /**
+     * These used to return null, which cached the failure as "no price" for 30 minutes and stopped
+     * UsdRepositoryFallback from trying Cow. Only a 404 is an answer.
+     */
+    it.each([429, 500, 502, 503])('throws on HTTP %s rather than reporting no price', async (status) => {
+      get.mockResolvedValue(errorResponse(status))
+
+      await expect(repository.getUsdPrice(chainId, WETH)).rejects.toThrow('Error getting USD price from Coingecko')
+      await expect(repository.getUsdPrices(chainId, WETH, '5m')).rejects.toThrow(
+        'Error getting USD prices from Coingecko'
+      )
+    })
+
+    it('returns null on 404, which is CoinGecko answering that it has no such token', async () => {
+      get.mockResolvedValue({ data: undefined, response: { status: 404, ok: false } as Response })
+
+      await expect(repository.getUsdPrice(chainId, WETH)).resolves.toBeNull()
+      await expect(repository.getUsdPrices(chainId, WETH, '5m')).resolves.toBeNull()
+    })
+
+    it('returns null on a 2xx that omits the token, which is also an answer', async () => {
+      get.mockResolvedValue(okResponse({}))
+
+      await expect(repository.getUsdPrice(chainId, WETH)).resolves.toBeNull()
+    })
+
+    it('treats a zero price as unknown rather than serving it', async () => {
+      get.mockResolvedValue(okResponse({ [WETH.toLowerCase()]: { usd: 0 } }))
+
+      await expect(repository.getUsdPrice(chainId, WETH)).resolves.toBeNull()
     })
   })
 })

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryCoingecko.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryCoingecko.ts
@@ -86,10 +86,17 @@ export class UsdRepositoryCoingecko implements UsdRepository {
   ): Promise<PricePoint[] | null> {
     const { data, response } = await marketDataPromise
 
-    if (response.status === 404 || !data) {
+    // Same split as the spot path: a 404 is an answer, any other non-2xx is a failure that must not
+    // be cached as "no price" or stop the fallback from trying Cow.
+    if (response.status === 404) {
       return null
     }
+
     await throwIfUnsuccessful('Error getting USD prices from Coingecko', response)
+
+    if (!data) {
+      return null
+    }
 
     const volumesMap =
       data.total_volumes?.reduce((acc, [timestamp, volume]) => {
@@ -142,13 +149,18 @@ export class UsdRepositoryCoingecko implements UsdRepository {
       response: Response
     }
 
-    if (response.status === 404 || !data?.[key]?.usd) {
+    // A 404 is an answer: Coingecko has no such coin or contract.
+    if (response.status === 404) {
       return null
     }
 
+    // Anything else non-2xx is a failure, not an answer. It has to throw: returning null here would
+    // cache it as "no price" for 30 minutes and stop the fallback from trying Cow.
     await throwIfUnsuccessful('Error getting USD price from Coingecko', response)
 
-    return data[key].usd
+    // A 2xx with the key absent is Coingecko saying it doesn't know the token. A zero price is
+    // treated as unknown too, rather than served as a real price.
+    return data?.[key]?.usd || null
   }
 
   private async getMarketDataByTokenAddress(

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.spec.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.spec.ts
@@ -369,7 +369,7 @@ describe('UsdRepositoryCoingecko', () => {
      * A null becomes a 404, and the frontend treats a 404 as proof the token has no price and stops
      * querying us for it for the rest of the session. An outage must never look like one.
      */
-    it('rethrows when every repository throws', async () => {
+    it('rethrows on the spot path when every repository throws, but not on the historical one', async () => {
       const error = new Error('Everything is down')
       const usdRepositoryFallback = new UsdRepositoryFallback(
         [createThrowingMock('First', error), createThrowingMock('Second', error)],
@@ -377,17 +377,33 @@ describe('UsdRepositoryCoingecko', () => {
       )
 
       await expect(usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)).rejects.toThrow('Everything is down')
-      await expect(usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)).rejects.toThrow('Everything is down')
+
+      // The historical path resolves instead: a null there is 0 bps with a 200, not a 404
+      await expect(usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)).resolves.toBeNull()
     })
 
-    it('rethrows when one repository throws and the rest find no price', async () => {
+    it('rethrows on the spot path when one throws and the rest find no price', async () => {
       const usdRepositoryFallback = new UsdRepositoryFallback(
         [usdRepositoryMock_null_null, createThrowingMock('Failing')],
         erc20RepositoryMock
       )
 
       await expect(usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)).rejects.toThrow('Failing is down')
-      await expect(usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)).rejects.toThrow('Failing is down')
+      await expect(usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)).resolves.toBeNull()
+    })
+
+    /**
+     * UsdRepositoryCow does not implement getUsdPrices at all, so on the historical path a Coingecko
+     * failure has no second source behind it. Rethrowing there turned every Coingecko outage into a 500
+     * for all of /slippageTolerance, instead of the 0 bps the consumers already read as "unknown".
+     */
+    it('does not turn a historical-path failure into an error when no source can answer', async () => {
+      const usdRepositoryFallback = new UsdRepositoryFallback(
+        [createThrowingMock('Coingecko'), usdRepositoryMock_null_null],
+        erc20RepositoryMock
+      )
+
+      await expect(usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)).resolves.toBeNull()
     })
 
     it('returns null without throwing when every repository cleanly reports no price', async () => {

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.spec.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.spec.ts
@@ -322,4 +322,82 @@ describe('UsdRepositoryCoingecko', () => {
       expect(erc20Repository.get).not.toHaveBeenCalled()
     })
   })
+
+  describe('upstream failures', () => {
+    const createRepositoryMock = (name: string): jest.Mocked<UsdRepository> => ({
+      name,
+      getUsdPrice: jest.fn().mockResolvedValue(1),
+      getUsdPrices: jest.fn().mockResolvedValue([{ date: mockDate, price: 1, volume: 1 }]),
+    })
+
+    const createThrowingMock = (name: string, error = new Error(`${name} is down`)): jest.Mocked<UsdRepository> => ({
+      name,
+      getUsdPrice: jest.fn().mockRejectedValue(error),
+      getUsdPrices: jest.fn().mockRejectedValue(error),
+    })
+
+    it('falls back to the next repository when one throws', async () => {
+      const failing = createThrowingMock('Failing')
+      const working = createRepositoryMock('Working')
+      const usdRepositoryFallback = new UsdRepositoryFallback([failing, working], erc20RepositoryMock)
+
+      await expect(usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)).resolves.toBe(1)
+      await expect(usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)).resolves.toEqual([
+        { date: mockDate, price: 1, volume: 1 },
+      ])
+
+      expect(working.getUsdPrice).toHaveBeenCalled()
+      expect(working.getUsdPrices).toHaveBeenCalled()
+    })
+
+    it('logs the failure and the repository it falls back to', async () => {
+      const loggerSpy = jest.spyOn(logger, 'warn')
+      const failing = createThrowingMock('Failing')
+      const usdRepositoryFallback = new UsdRepositoryFallback(
+        [failing, createRepositoryMock('Working')],
+        erc20RepositoryMock
+      )
+
+      await usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        `UsdRepositoryFallback: Failing failed for ${PARAMS_PRICE[0]}/${PARAMS_PRICE[1]}, falling back to Working: Failing is down`
+      )
+    })
+
+    /**
+     * A null becomes a 404, and the frontend treats a 404 as proof the token has no price and stops
+     * querying us for it for the rest of the session. An outage must never look like one.
+     */
+    it('rethrows when every repository throws', async () => {
+      const error = new Error('Everything is down')
+      const usdRepositoryFallback = new UsdRepositoryFallback(
+        [createThrowingMock('First', error), createThrowingMock('Second', error)],
+        erc20RepositoryMock
+      )
+
+      await expect(usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)).rejects.toThrow('Everything is down')
+      await expect(usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)).rejects.toThrow('Everything is down')
+    })
+
+    it('rethrows when one repository throws and the rest find no price', async () => {
+      const usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_null_null, createThrowingMock('Failing')],
+        erc20RepositoryMock
+      )
+
+      await expect(usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)).rejects.toThrow('Failing is down')
+      await expect(usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)).rejects.toThrow('Failing is down')
+    })
+
+    it('returns null without throwing when every repository cleanly reports no price', async () => {
+      const usdRepositoryFallback = new UsdRepositoryFallback(
+        [usdRepositoryMock_null_null, usdRepositoryMock_null_null],
+        erc20RepositoryMock
+      )
+
+      await expect(usdRepositoryFallback.getUsdPrice(...PARAMS_PRICE)).resolves.toBeNull()
+      await expect(usdRepositoryFallback.getUsdPrices(...PARAMS_PRICES)).resolves.toBeNull()
+    })
+  })
 })

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
@@ -38,21 +38,9 @@ export class UsdRepositoryFallback implements UsdRepository {
       return null
     }
 
-    for (let i = 0; i < this.usdRepositories.length; i++) {
-      const usdRepository = this.usdRepositories[i]
-      const price = await usdRepository.getUsdPrice(chainIdOrSlug, tokenAddress)
-      if (price !== null) {
-        return price
-      }
-
-      if (i < this.usdRepositories.length - 1) {
-        const nextRepository = this.usdRepositories[i + 1]
-        logger.info(
-          `UsdRepositoryFallback: ${usdRepository.name} returned null for ${chainIdOrSlug}/${tokenAddress}, falling back to ${nextRepository.name}`
-        )
-      }
-    }
-    return null
+    return this.firstNonNull(chainIdOrSlug, tokenAddress, (usdRepository) =>
+      usdRepository.getUsdPrice(chainIdOrSlug, tokenAddress)
+    )
   }
 
   async getUsdPrices(
@@ -68,20 +56,61 @@ export class UsdRepositoryFallback implements UsdRepository {
       return null
     }
 
+    return this.firstNonNull(chainIdOrSlug, tokenAddress, (usdRepository) =>
+      usdRepository.getUsdPrices(chainIdOrSlug, tokenAddress, priceStrategy)
+    )
+  }
+
+  /**
+   * Queries the repositories in order and returns the first non-null result.
+   *
+   * A repository that throws is treated like one that returned null, so an upstream failure doesn't
+   * deny a price the next source can still serve. That is the point of this class, and previously a
+   * Coingecko or Redis error escaped as a 500 instead of falling back to Cow.
+   *
+   * If nothing produced a price and any repository failed, the error is rethrown rather than reported
+   * as "no price". A null here becomes a 404, and the frontend treats a 404 as proof the token has no
+   * price and stops asking us for it for the rest of the session, so an outage must never look like
+   * one. See getBffUsdPrice/fetchCurrencyUsdPrice in cowswap.
+   */
+  private async firstNonNull<T>(
+    chainIdOrSlug: string,
+    tokenAddress: string | undefined,
+    getResult: (usdRepository: UsdRepository) => Promise<T | null>
+  ): Promise<T | null> {
+    let failure: unknown
+
     for (let i = 0; i < this.usdRepositories.length; i++) {
       const usdRepository = this.usdRepositories[i]
-      const prices = await usdRepository.getUsdPrices(chainIdOrSlug, tokenAddress, priceStrategy)
-      if (prices !== null) {
-        return prices
-      }
+      const nextRepository = this.usdRepositories[i + 1]
+      const fallingBackTo = nextRepository ? `, falling back to ${nextRepository.name}` : ''
 
-      if (i < this.usdRepositories.length - 1) {
-        const nextRepository = this.usdRepositories[i + 1]
-        logger.info(
-          `UsdRepositoryFallback: ${usdRepository.name} returned null for ${chainIdOrSlug}/${tokenAddress}, falling back to ${nextRepository.name}`
+      try {
+        const result = await getResult(usdRepository)
+
+        if (result !== null) {
+          return result
+        }
+
+        if (nextRepository) {
+          logger.info(
+            `UsdRepositoryFallback: ${usdRepository.name} returned null for ${chainIdOrSlug}/${tokenAddress}${fallingBackTo}`
+          )
+        }
+      } catch (error) {
+        failure = error
+        logger.warn(
+          `UsdRepositoryFallback: ${usdRepository.name} failed for ${chainIdOrSlug}/${tokenAddress}${fallingBackTo}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
         )
       }
     }
+
+    if (failure !== undefined) {
+      throw failure
+    }
+
     return null
   }
 

--- a/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
+++ b/libs/repositories/src/repos/UsdRepository/UsdRepositoryFallback.ts
@@ -38,8 +38,12 @@ export class UsdRepositoryFallback implements UsdRepository {
       return null
     }
 
-    return this.firstNonNull(chainIdOrSlug, tokenAddress, (usdRepository) =>
-      usdRepository.getUsdPrice(chainIdOrSlug, tokenAddress)
+    return this.firstNonNull(
+      chainIdOrSlug,
+      tokenAddress,
+      (usdRepository) => usdRepository.getUsdPrice(chainIdOrSlug, tokenAddress),
+      // A null here becomes a 404, which the frontend takes as proof the token has no price
+      { rethrowOnFailure: true }
     )
   }
 
@@ -56,8 +60,12 @@ export class UsdRepositoryFallback implements UsdRepository {
       return null
     }
 
-    return this.firstNonNull(chainIdOrSlug, tokenAddress, (usdRepository) =>
-      usdRepository.getUsdPrices(chainIdOrSlug, tokenAddress, priceStrategy)
+    return this.firstNonNull(
+      chainIdOrSlug,
+      tokenAddress,
+      (usdRepository) => usdRepository.getUsdPrices(chainIdOrSlug, tokenAddress, priceStrategy),
+      // A null here becomes 0 bps with a 200, not a 404, so there is nothing to protect against
+      { rethrowOnFailure: false }
     )
   }
 
@@ -68,15 +76,23 @@ export class UsdRepositoryFallback implements UsdRepository {
    * deny a price the next source can still serve. That is the point of this class, and previously a
    * Coingecko or Redis error escaped as a 500 instead of falling back to Cow.
    *
-   * If nothing produced a price and any repository failed, the error is rethrown rather than reported
-   * as "no price". A null here becomes a 404, and the frontend treats a 404 as proof the token has no
-   * price and stops asking us for it for the rest of the session, so an outage must never look like
-   * one. See getBffUsdPrice/fetchCurrencyUsdPrice in cowswap.
+   * `rethrowOnFailure` decides what happens when nothing produced a price and something failed. It
+   * exists to stop a null being mistaken for "this token has no price", which only matters where a
+   * null becomes a **404**:
+   *
+   * - getUsdPrice: a null is a 404, and cowswap records that token in `bffUnknownCurrencies` and stops
+   *   asking us for it for the rest of the session. An outage must never look like one, so it rethrows.
+   *   See getBffUsdPrice/fetchCurrencyUsdPrice in cowswap.
+   * - getUsdPrices: a null is 0 bps with a **200**, which every consumer already reads as "unknown"
+   *   and answers with its own default. There is no 404 to avoid, and UsdRepositoryCow does not
+   *   implement this method at all, so rethrowing would turn every Coingecko failure into a 500 for
+   *   the whole of /slippageTolerance rather than degrading to that default.
    */
   private async firstNonNull<T>(
     chainIdOrSlug: string,
     tokenAddress: string | undefined,
-    getResult: (usdRepository: UsdRepository) => Promise<T | null>
+    getResult: (usdRepository: UsdRepository) => Promise<T | null>,
+    { rethrowOnFailure }: { rethrowOnFailure: boolean }
   ): Promise<T | null> {
     let failure: unknown
 
@@ -107,7 +123,7 @@ export class UsdRepositoryFallback implements UsdRepository {
       }
     }
 
-    if (failure !== undefined) {
+    if (failure !== undefined && rethrowOnFailure) {
       throw failure
     }
 


### PR DESCRIPTION
# Summary

Another part of https://linear.app/cowswap/issue/FE-449/address-coingecko-fallback-issues-in-bff

Don't return a 500 on first 500 found. Try all repositories instead as one might have a price.

## Details

Make fallback work on upstream errors, not just null, and stop caching upstream errors as "no price". Implemented together, since neither works alone: fixing only the fallback is inert because Coingecko failures never reach it as throws, and fixing only Coingecko would turn its errors straight into 500s.

- UsdRepositoryFallback had a bare await per repository, so a throw aborted the loop and escaped as a 500 instead of trying the next source. A throw is now treated like a null and the next source is tried.

- Both Coingecko response handlers short-circuited before throwIfUnsuccessful: a 429 or 5xx carries no price field, matched the !data?.[key]?.usd condition and returned null. That null was cached for the 30 minute NULL TTL, hid the outage behind a 404 long after recovery, and made the fallback log line count failures as unknown tokens. Only a 404 is now treated as an answer.

- When no price is found and any source failed, the error is rethrown rather than reported as no price. Reason below in the notes: a 404 makes the frontend blacklist the token for the whole session, so an outage must never look like one.

- UsdRepositoryCache needed no change, since cacheValue already sits after the await and a throw skips it. That was implicit and is now asserted in tests.

- Watch after deploy: this deliberately converts a class of silent 404s into 5xx. Volume is unknown precisely because these failures have been recorded as nulls until now.

# Testing

- Unit tests
- Ran coingecko e2e locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved USD price handling when upstream pricing services experience errors.
  - Invalid or unsuccessful responses now surface as errors instead of being incorrectly treated as unavailable prices.
  - Confirmed that failed price lookups are not cached as missing values.
  - Fallback pricing sources are now tried more reliably, with failures recorded and successful results returned when available.
  - Missing prices, unavailable tokens, zero-valued prices, and not-found responses continue to be handled appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->